### PR TITLE
fix: Container Image Testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,11 @@ tls:
 
 .PHONY: docker-http
 docker-http:
-	docker run -d -p 3010:3001 --name "bindplane-server-${GIT_SHA}-http" "observiq/bindplane-$(GOARCH):${GIT_SHA}" \
+	docker run -d -p 3010:3001 \
+		--name "bindplane-server-${GIT_SHA}-http" \
+		-e BINDPLANE_CONFIG_SESSIONS_SECRET=403dd8ff-72a9-4401-9a66-e54b37d6e0ce \
+		-e BINDPLANE_CONFIG_LOG_OUTPUT=stdout \
+		"observiq/bindplane-$(GOARCH):${GIT_SHA}" \
 		--host 0.0.0.0 \
 		--port "3001" \
 		--server-url http://localhost:3010 \
@@ -158,6 +162,8 @@ docker-https: tls
 	docker run -d \
 		-p 3011:3001 \
 		--name "bindplane-server-${GIT_SHA}-https" \
+		-e BINDPLANE_CONFIG_SESSIONS_SECRET=403dd8ff-72a9-4401-9a66-e54b37d6e0ce \
+		-e BINDPLANE_CONFIG_LOG_OUTPUT=stdout \
 		-v "${PWD}/tls:/tls" \
 		"observiq/bindplane-$(GOARCH):latest" \
 			--tls-cert /tls/bindplane.crt --tls-key /tls/bindplane.key \
@@ -178,6 +184,8 @@ docker-https-mtls: tls
 	docker run -d \
 		-p 3012:3001 \
 		--name "bindplane-server-${GIT_SHA}-https-mtls" \
+		-e BINDPLANE_CONFIG_SESSIONS_SECRET=403dd8ff-72a9-4401-9a66-e54b37d6e0ce \
+		-e BINDPLANE_CONFIG_LOG_OUTPUT=stdout \
 		-v "${PWD}/tls:/tls" \
 		"observiq/bindplane-$(GOARCH):latest" \
 			--tls-cert /tls/bindplane.crt --tls-key /tls/bindplane.key --tls-ca /tls/bindplane-ca.crt --tls-ca /tls/test-ca.crt \
@@ -198,7 +206,7 @@ docker-all: docker-clean docker-http docker-https docker-https-mtls
 
 .PHONY: docker-clean
 docker-clean:
-	docker ps | grep bindplane-server | awk '{print $$1}' | xargs -I{} docker rm --force {}
+	docker ps -a | grep bindplane-server | awk '{print $$1}' | xargs -I{} docker rm --force {}
 
 # Call 'release-test' first.
 .PHONY: inspec-continer-image

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ tls:
 
 .PHONY: docker-http
 docker-http:
-	docker run -d -p 3010:3001 --name "bindplane-server-${GIT_SHA}-http" "observiq/bindplane-$(GOARCH):latest" \
+	docker run -d -p 3010:3001 --name "bindplane-server-${GIT_SHA}-http" "observiq/bindplane-$(GOARCH):${GIT_SHA}" \
 		--host 0.0.0.0 \
 		--port "3001" \
 		--server-url http://localhost:3010 \

--- a/test/inspec/docker/integration.rb
+++ b/test/inspec/docker/integration.rb
@@ -13,17 +13,6 @@ describe file('/bindplane') do
 end
 
 [
-    "/data/bindplane.log",
-].each do |dir|
-    describe file(dir) do
-        its('mode') { should cmp '0644' }
-        its('owner') { should eq 'bindplane' }
-        its('group') { should eq 'bindplane' }
-        its('type') { should cmp 'file' }
-    end
-end
-
-[
     "data/storage",
 ].each do |dir|
     describe file(dir) do


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Pointing to `latest` was only working because `latest` is tagged on release. The workflow was never testing the image it built, rather it was testing the most recent release. Because we released v0.5.0, we get container image failures due to the missing parameter for session secrets.

This PR fixes this by calling the image built by Goreleaser and adding the missing parameter to the test container.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
