### PR TITLE
fix(UI): Import configuration dialog now scrolls to show very long configuration.

### DIFF
--- a/ui/src/components/Wizard/wizard.module.scss
+++ b/ui/src/components/Wizard/wizard.module.scss
@@ -33,6 +33,7 @@
   flex-grow: 1;
   padding: 20px;
   background-color: rgb(248, 249, 250);
+  text-align: left;
 }
 
 .buttons {

--- a/ui/src/pages/agents/agent.tsx
+++ b/ui/src/pages/agents/agent.tsx
@@ -156,6 +156,7 @@ const AgentPageContent: React.FC = () => {
         open={importOpen}
         onClose={() => setImportOpen(false)}
         PaperComponent={EmptyComponent}
+        scroll={"body"}
       >
         <DialogContent>
           <Stack justifyContent="center" alignItems="center" height="100%">


### PR DESCRIPTION
### Proposed Change
Previously we were not allowing the Import Dialog to scroll, so if an agent had a very long configuration - it would be cutoff and unable to be viewed.

Before:
![image](https://user-images.githubusercontent.com/64915094/177349206-3e3ee46a-d1ef-40e1-8290-2976317f99ae.png)


After:

https://user-images.githubusercontent.com/64915094/177349309-43f2bbc1-0698-459f-8f52-d9cda434a71a.mov



##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
