### PR TITLE
fix: macOS source log path formatting

### DIFF
--- a/resources/source-types/macos.yaml
+++ b/resources/source-types/macos.yaml
@@ -125,9 +125,11 @@ spec:
           path: $OIQ_OTEL_COLLECTOR_HOME/plugins/macos_logs.yaml
           parameters:
             enable_system_log: {{ .enable_system_log }}
-            system_log_path: {{ .system_log_path }}
+            system_log_path:
+            - "{{ .system_log_path }}"
             enable_install_log: {{ .enable_install_log }}
-            install_log_path: {{ .install_log_path }}
+            install_log_path:
+            - "{{ .install_log_path }}"
             start_at: {{ .start_at }}
       {{ end }}
 


### PR DESCRIPTION
### Proposed Change
Formats the log path parameters as YAML arrays. The macOS plugin accepts multiple values for the log paths. BindPlane will still present the user with a single input and but will render the output as a single element YAML array.

Resolves #49 

##### Checklist
- [x] Changes are tested
- [x] CI has passed
