### PR TITLE
feat(UI): Use CSS calc() for agents table min height.

### DIFF
--- a/ui/src/components/Tables/AgentsTable/AgentsDataGrid.tsx
+++ b/ui/src/components/Tables/AgentsTable/AgentsDataGrid.tsx
@@ -15,8 +15,6 @@ import { Link } from "react-router-dom";
 import { AgentStatus } from "../../../types/agents";
 import { isFunction } from "lodash";
 
-import mixins from "../../../styles/mixins.module.scss";
-
 export enum AgentsTableField {
   NAME = "name",
   STATUS = "status",
@@ -128,9 +126,6 @@ const AgentsDataGridComponent: React.FC<AgentsDataGridProps> = ({
       style={{ minHeight }}
       loading={loading}
       disableSelectionOnClick
-      getCellClassName={() => {
-        return mixins["flex-wrap"];
-      }}
       columns={columns}
       rows={agents ?? []}
     />
@@ -166,7 +161,7 @@ function renderStatusDataCell(
 }
 
 AgentsDataGridComponent.defaultProps = {
-  minHeight: "60vh",
+  minHeight: "calc(100vh - 300px)",
   columnFields: [
     AgentsTableField.NAME,
     AgentsTableField.STATUS,


### PR DESCRIPTION
### Proposed Change
Previously we were setting the default `minHeight` of the agents table to 60vh - which didn't scale well for larger displays.

We can use the css `calc` function to make this fit larger screens better.

![image](https://user-images.githubusercontent.com/64915094/177417147-7a2b7dcf-d5d8-4af8-891a-6800fb7d18c2.png)


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
