### PR TITLE
feat: /swagger endpoint will redirect to Swagger docs.

### DIFF
--- a/docs/swagger/routes.go
+++ b/docs/swagger/routes.go
@@ -1,3 +1,17 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package swagger
 
 import (

--- a/docs/swagger/routes.go
+++ b/docs/swagger/routes.go
@@ -22,6 +22,7 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
+// AddRoutes adds the routes for swagger docs to the router.
 func AddRoutes(router gin.IRouter) {
 	// Swagger documentation
 	SwaggerInfo.BasePath = "/v1"

--- a/docs/swagger/routes.go
+++ b/docs/swagger/routes.go
@@ -1,0 +1,18 @@
+package swagger
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	swaggerfiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+)
+
+func AddRoutes(router gin.IRouter) {
+	// Swagger documentation
+	SwaggerInfo.BasePath = "/v1"
+	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+	router.GET("/swagger", func(ctx *gin.Context) {
+		ctx.Redirect(http.StatusPermanentRedirect, "/swagger/index.html")
+	})
+}

--- a/docs/swagger/routes_test.go
+++ b/docs/swagger/routes_test.go
@@ -1,3 +1,17 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package swagger
 
 import (

--- a/docs/swagger/routes_test.go
+++ b/docs/swagger/routes_test.go
@@ -1,0 +1,37 @@
+package swagger
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddRoutes(t *testing.T) {
+	// Add routes
+	router := gin.Default()
+	AddRoutes(router)
+
+	// Start server
+	svr := httptest.NewServer(router)
+	defer svr.Close()
+
+	// create client
+	client := resty.New()
+	client.SetBaseURL(svr.URL)
+
+	t.Run("hosts docs at /swagger/index.html", func(t *testing.T) {
+		resp, err := client.R().Get("/swagger/index.html")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+	})
+
+	t.Run("redirects from /swagger", func(t *testing.T) {
+		resp, err := client.R().Get("/swagger")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+	})
+}

--- a/internal/cli/commands/serve/start.go
+++ b/internal/cli/commands/serve/start.go
@@ -126,9 +126,6 @@ func (s *Server) Start(bindplane *cli.BindPlane, h profile.Helper, forceConsoleC
 	// Swagger documentation
 	swagger.AddRoutes(router)
 
-	// swaggerdocs.SwaggerInfo.BasePath = "/v1"
-	// router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
-
 	// opamp does its own authorization based on the OnConnecting callback
 	err = opamp.AddRoutes(v1, server)
 	if err != nil {

--- a/internal/cli/commands/serve/start.go
+++ b/internal/cli/commands/serve/start.go
@@ -28,13 +28,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/hashicorp/go-multierror"
 	cors "github.com/itsjamie/gin-cors"
-	swaggerfiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 	"go.uber.org/zap"
 
 	"github.com/observiq/bindplane-op/common"
-	swaggerdocs "github.com/observiq/bindplane-op/docs/swagger"
+	"github.com/observiq/bindplane-op/docs/swagger"
 	"github.com/observiq/bindplane-op/internal/agent"
 	"github.com/observiq/bindplane-op/internal/cli"
 	"github.com/observiq/bindplane-op/internal/cli/commands/profile"
@@ -126,8 +124,10 @@ func (s *Server) Start(bindplane *cli.BindPlane, h profile.Helper, forceConsoleC
 	graphql.AddRoutes(authv1, server)
 
 	// Swagger documentation
-	swaggerdocs.SwaggerInfo.BasePath = "/v1"
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+	swagger.AddRoutes(router)
+
+	// swaggerdocs.SwaggerInfo.BasePath = "/v1"
+	// router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 
 	// opamp does its own authorization based on the OnConnecting callback
 	err = opamp.AddRoutes(v1, server)


### PR DESCRIPTION
Resolves #101 

### Proposed Change
The swagger docs are hosted at `/swagger/index.html` which is hard to remember.  Lets redirect there from `/swagger` to make it easier to remember and pass on to Users.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
