### PR TITLE
fix(UI): Break word for values in the parameter tables in the Assisted Config Wizard.

### DIFF
--- a/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepThree.tsx
+++ b/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepThree.tsx
@@ -312,7 +312,9 @@ export const StepThree: React.FC = () => {
                   return (
                     <TableRow key={p.name}>
                       <TableCell>{label}</TableCell>
-                      <TableCell>{String(p.value)}</TableCell>
+                      <TableCell classes={{ root: styles["break-word-cell"] }}>
+                        {String(p.value)}
+                      </TableCell>
                     </TableRow>
                   );
                 })}

--- a/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepTwo.tsx
+++ b/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepTwo.tsx
@@ -155,7 +155,9 @@ export const StepTwo: React.FC = (props) => {
                 return (
                   <TableRow key={param.name}>
                     <TableCell>{label}</TableCell>
-                    <TableCell>{String(param.value)}</TableCell>
+                    <TableCell classes={{ root: styles["break-word-cell"] }}>
+                      {String(param.value)}
+                    </TableCell>
                   </TableRow>
                 );
               })}

--- a/ui/src/pages/configurations/wizards/AssistedConfigWizard/assisted-config-wizard.module.scss
+++ b/ui/src/pages/configurations/wizards/AssistedConfigWizard/assisted-config-wizard.module.scss
@@ -43,3 +43,8 @@
   width: 40px;
   height: 40px;
 }
+
+.break-word-cell {
+  word-break: break-word;
+  white-space: normal;
+}


### PR DESCRIPTION
### Proposed Change
<!-- Please provide a description of the change here. -->
In Chrome and Safari very large values for Destination + Source parameters would cause a large horizontal scroll.

Before:
![image](https://user-images.githubusercontent.com/64915094/178808952-fdf8e363-8ce6-455b-b222-a98028502485.png)

After:
![image](https://user-images.githubusercontent.com/64915094/178809140-f9c60561-436d-4825-af56-4c2a44d5da52.png)


##### Checklist
- [x] Changes are tested
- [x] CI has passed
