### PR TITLE
fix(UI): Agents data grid name sort.

### DIFF
--- a/ui/src/components/Tables/AgentsTable/AgentsDataGrid.tsx
+++ b/ui/src/components/Tables/AgentsTable/AgentsDataGrid.tsx
@@ -91,10 +91,7 @@ const AgentsDataGridComponent: React.FC<AgentsDataGridProps> = ({
           field: AgentsTableField.NAME,
           headerName: "Name",
           valueGetter: (params: GridValueGetterParams<Agent>) => {
-            return {
-              name: params.row.name,
-              id: params.row.id,
-            };
+            return params.row.name;
           },
           renderCell: renderNameDataCell,
           width: 325,
@@ -141,11 +138,9 @@ function renderConfigurationCell(cellParams: GridCellParams<string>) {
 }
 
 function renderNameDataCell(
-  cellParams: GridCellParams<{ name: string; id: string }>
+  cellParams: GridCellParams<{ name: string; id: string }, Agent>
 ): JSX.Element {
-  return (
-    <Link to={`/agents/${cellParams.value?.id}`}>{cellParams.value?.name}</Link>
-  );
+  return <Link to={`/agents/${cellParams.row.id}`}>{cellParams.row.name}</Link>;
 }
 
 function renderLabelDataCell(


### PR DESCRIPTION
Resolves: #73 

### Proposed Change
The sort is determined by the row value which is determined by the `valueGetter` function.  So we can fix that to get the agent name value, `agent.name`.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
