### PR TITLE
fix(source-type): File Log - conditionally render the exclude file paths parameters

### DIFF
--- a/resources/source-types/file_log.yaml
+++ b/resources/source-types/file_log.yaml
@@ -90,11 +90,13 @@ spec:
             file_path:
               {{ range $fp := .file_path }}
               - '{{ $fp }}'
-              {{end}}
+              {{ end }}
+            {{ if .exclude_file_path }}
             exclude_file_path:
               {{ range $fp := .exclude_file_path }}
               - '{{ $fp }}'
               {{end}}
+            {{ end }}
             multiline_line_start_pattern: '{{ .multiline_line_start_pattern }}'
             encoding: {{ .encoding }}
             parse_format: {{ .parse_format }}


### PR DESCRIPTION
### Proposed Change
Conditionally render the exclude_file_path parameter so that the default form values will work without error.


Previously, configuring a file source with an empty value for `exclude_file_path` would result in an agent error.  Now we conditionally render that block to avoid setting the value as `null` when it should be an empty array.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
