### PR TITLE
fix: Validate required for Strings input

### DIFF
--- a/ui/src/components/ResourceTypeForm/ResourceForm.test.tsx
+++ b/ui/src/components/ResourceTypeForm/ResourceForm.test.tsx
@@ -183,4 +183,35 @@ describe("ResourceForm component", () => {
 
     expect(screen.getByTestId("resource-form-save")).toBeDisabled();
   });
+
+  it("strings type parameter validation", async () => {
+    const label = "p1 label";
+    const definitions: ParameterDefinition[] = [
+      {
+        name: "p1",
+        label: label,
+        type: ParameterType.Strings,
+        required: true,
+        description: "",
+      },
+    ];
+
+    render(
+      <ResourceConfigForm
+        onSave={() => {}}
+        kind="destination"
+        title={"Title"}
+        description={ResourceType1.metadata.description!}
+        parameterDefinitions={definitions}
+      />
+    );
+
+    expect(screen.getByTestId("resource-form-save")).toBeDisabled();
+
+    const input = screen.getByLabelText(`${label} *`);
+    fireEvent.change(input, { target: { value: "/tmp.file.log" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter", charCode: 13 });
+
+    expect(screen.getByTestId("resource-form-save")).not.toBeDisabled();
+  });
 });

--- a/ui/src/components/ResourceTypeForm/ValidationContext.tsx
+++ b/ui/src/components/ResourceTypeForm/ValidationContext.tsx
@@ -21,8 +21,16 @@ const defaultValue: ValidationContextValue = {
 
 const ValidationContext = createContext(defaultValue);
 
-export const ValidationContextProvider: React.FC = ({ children }) => {
-  const [errors, setErrors] = useState<Record<string, string | null>>({});
+interface Props {
+  initErrors: Record<string, string | null>;
+}
+
+export const ValidationContextProvider: React.FC<Props> = ({
+  children,
+  initErrors,
+}) => {
+  const [errors, setErrors] =
+    useState<Record<string, string | null>>(initErrors);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
 
   function setError(parameterName: string, error: string | null) {

--- a/ui/src/components/ResourceTypeForm/validation-functions.test.ts
+++ b/ui/src/components/ResourceTypeForm/validation-functions.test.ts
@@ -1,0 +1,13 @@
+import { validateStringsField } from "./validation-functions";
+
+describe("validateStringsField", () => {
+  it("[], required", () => {
+    const error = validateStringsField([], true);
+    expect(error).not.toBeNull();
+  });
+
+  it("[], not required", () => {
+    const error = validateStringsField([], false);
+    expect(error).toBeNull();
+  });
+});

--- a/ui/src/components/ResourceTypeForm/validation-functions.ts
+++ b/ui/src/components/ResourceTypeForm/validation-functions.ts
@@ -1,0 +1,12 @@
+import { isEmpty } from "lodash";
+
+export function validateStringsField(
+  value: string[],
+  required?: boolean
+): string | null {
+  if (required && isEmpty(value)) {
+    return "Required.";
+  }
+
+  return null;
+}


### PR DESCRIPTION
Resolves: https://github.com/observIQ/bindplane-op/issues/153

### Proposed Change

- Disable the save button in the resource configuration form when a required strings input is empty.

### Explanation

Even though we could define a strings input as required - there was no form validation happening to ensure that a user could not save the form with an empty value.

This is important for the `file_log` source - where the File Path(s) parameter is required, and an empty value (`[]`) will result in an agent error.

We can now initialize the `validationContext` with `initErrors` - making it so a user cannot configure a source that will cause issues when rendered.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
