### PR TITLE
fix: 500 Error when we recieve a cookie with a bad secret.

### DIFF
--- a/internal/server/auth/session.go
+++ b/internal/server/auth/session.go
@@ -29,6 +29,11 @@ func CheckSession(server server.BindPlane) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		session, err := server.Store().UserSessions().Get(c.Request, sessions.CookieName)
 		if err != nil {
+			// Clear the cookie, this can happen when sessions-secrets are changed
+			// and a cookie with the previous secret is read.
+			session.Options.MaxAge = 0
+			session.Save(c.Request, c.Writer)
+
 			c.AbortWithError(http.StatusInternalServerError, err)
 			return
 		}


### PR DESCRIPTION
Resolves: https://github.com/observIQ/bindplane-op/issues/155

### Proposed Change

- Clear the cookie if we cannot read it in the CheckSession middleware
- This should really be status unauthorized anyway.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
