### PR TITLE
feat: Users can duplicate a config via REST and UI

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -523,6 +523,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/configurations/{name}/duplicate": {
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Duplicate an existing configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "the name of the configuration to duplicate",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "the desired name of the duplicate configuration",
+                        "name": "name",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successful Duplication, created"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/delete": {
             "post": {
                 "description": "/delete endpoint will try to parse resources\nand delete them from the store.  Additionally\nit will send reconfigure tasks to affected agents.",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -524,7 +524,7 @@ const docTemplate = `{
             }
         },
         "/configurations/{name}/duplicate": {
-            "put": {
+            "post": {
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -497,6 +497,55 @@
                 }
             }
         },
+        "/configurations/{name}/duplicate": {
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Duplicate an existing configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "the name of the configuration to duplicate",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "the desired name of the duplicate configuration",
+                        "name": "name",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successful Duplication, created"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/delete": {
             "post": {
                 "description": "/delete endpoint will try to parse resources\nand delete them from the store.  Additionally\nit will send reconfigure tasks to affected agents.",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -498,7 +498,7 @@
             }
         },
         "/configurations/{name}/duplicate": {
-            "put": {
+            "post": {
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -785,6 +785,38 @@ paths:
           schema:
             $ref: '#/definitions/rest.ErrorResponse'
       summary: Get configuration by name
+  /configurations/{name}/duplicate:
+    put:
+      parameters:
+      - description: the name of the configuration to duplicate
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: the desired name of the duplicate configuration
+        in: body
+        name: name
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Successful Duplication, created
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+      summary: Duplicate an existing configuration
   /delete:
     post:
       description: |-

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -786,7 +786,7 @@ paths:
             $ref: '#/definitions/rest.ErrorResponse'
       summary: Get configuration by name
   /configurations/{name}/duplicate:
-    put:
+    post:
       parameters:
       - description: the name of the configuration to duplicate
         in: path

--- a/internal/rest/api.go
+++ b/internal/rest/api.go
@@ -48,7 +48,7 @@ func AddRestRoutes(router gin.IRouter, bindplane server.BindPlane) {
 	router.GET("/configurations", func(c *gin.Context) { configurations(c, bindplane) })
 	router.GET("/configurations/:name", func(c *gin.Context) { configuration(c, bindplane) })
 	router.DELETE("/configurations/:name", func(c *gin.Context) { deleteConfiguration(c, bindplane) })
-	router.PUT("/configurations/:name/duplicate", func(c *gin.Context) { duplicateConfig(c, bindplane) })
+	router.POST("/configurations/:name/duplicate", func(c *gin.Context) { duplicateConfig(c, bindplane) })
 
 	router.GET("/sources", func(c *gin.Context) { sources(c, bindplane) })
 	router.GET("/sources/:name", func(c *gin.Context) { source(c, bindplane) })
@@ -479,7 +479,7 @@ func deleteConfiguration(c *gin.Context, bindplane server.BindPlane) {
 
 // @Summary Duplicate an existing configuration
 // @Produce json
-// @Router /configurations/{name}/duplicate [put]
+// @Router /configurations/{name}/duplicate [post]
 // @Param 	name	path	string	true "the name of the configuration to duplicate"
 // @Param name	body	string	true "the desired name of the duplicate configuration"
 // @Success 201	"Successful Duplication, created"
@@ -502,7 +502,7 @@ func duplicateConfig(c *gin.Context, bindplane server.BindPlane) {
 		return
 	}
 
-	var req model.PutDuplicateConfigRequest
+	var req model.PostDuplicateConfigRequest
 	if err := c.BindJSON(&req); err != nil {
 		handleErrorResponse(c, http.StatusBadRequest, err)
 		return
@@ -528,7 +528,7 @@ func duplicateConfig(c *gin.Context, bindplane server.BindPlane) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, &model.PutDuplicateConfigResponse{
+	c.JSON(http.StatusCreated, &model.PostDuplicateConfigResponse{
 		Name: duplicateName,
 	})
 }

--- a/internal/rest/api.go
+++ b/internal/rest/api.go
@@ -48,6 +48,7 @@ func AddRestRoutes(router gin.IRouter, bindplane server.BindPlane) {
 	router.GET("/configurations", func(c *gin.Context) { configurations(c, bindplane) })
 	router.GET("/configurations/:name", func(c *gin.Context) { configuration(c, bindplane) })
 	router.DELETE("/configurations/:name", func(c *gin.Context) { deleteConfiguration(c, bindplane) })
+	router.PUT("/configurations/:name/duplicate", func(c *gin.Context) { duplicateConfig(c, bindplane) })
 
 	router.GET("/sources", func(c *gin.Context) { sources(c, bindplane) })
 	router.GET("/sources/:name", func(c *gin.Context) { source(c, bindplane) })
@@ -474,6 +475,62 @@ func deleteConfiguration(c *gin.Context, bindplane server.BindPlane) {
 	if okResource(c, configuration == nil, err) {
 		c.Status(http.StatusNoContent)
 	}
+}
+
+// @Summary Duplicate an existing configuration
+// @Produce json
+// @Router /configurations/{name}/duplicate [put]
+// @Param 	name	path	string	true "the name of the configuration to duplicate"
+// @Param name	body	string	true "the desired name of the duplicate configuration"
+// @Success 201	"Successful Duplication, created"
+// @Failure 404 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 409 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+func duplicateConfig(c *gin.Context, bindplane server.BindPlane) {
+	name := c.Param("name")
+
+	// The config to make a duplicate of
+	config, err := bindplane.Store().Configuration(name)
+	if err != nil {
+		handleErrorResponse(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	if config == nil {
+		handleErrorResponse(c, http.StatusNotFound, fmt.Errorf("no configuration with name %s found", name))
+		return
+	}
+
+	var req model.PutDuplicateConfigRequest
+	if err := c.BindJSON(&req); err != nil {
+		handleErrorResponse(c, http.StatusBadRequest, err)
+		return
+	}
+
+	duplicateName := req.Name
+	duplicateConfig, err := bindplane.Store().Configuration(duplicateName)
+	if err != nil {
+		handleErrorResponse(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	if duplicateConfig != nil {
+		handleErrorResponse(c, http.StatusConflict, errors.New("a configuration with that name already exists"))
+		return
+	}
+
+	duplicateConfig = config.Duplicate(duplicateName)
+
+	_, err = bindplane.Store().ApplyResources([]model.Resource{duplicateConfig})
+	if err != nil {
+		handleErrorResponse(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, &model.PutDuplicateConfigResponse{
+		Name: duplicateName,
+	})
 }
 
 // ----------------------------------------------------------------------

--- a/internal/rest/api_test.go
+++ b/internal/rest/api_test.go
@@ -638,7 +638,7 @@ func TestREST(t *testing.T) {
 		assert.NotContains(t, configurations, testConfiguration1)
 	})
 
-	t.Run("PUT /configurations/:name/duplicate", func(t *testing.T) {
+	t.Run("POST /configurations/:name/duplicate", func(t *testing.T) {
 		resetStore(t, s)
 		originalName := "original"
 		newName := "newName"
@@ -652,7 +652,7 @@ func TestREST(t *testing.T) {
 		t.Run("404 Not Found", func(t *testing.T) {
 			endpoint := "/configurations/does-not-exist/duplicate"
 
-			resp, err := client.R().SetBody(&model.PutDuplicateConfigRequest{Name: newName}).Put(endpoint)
+			resp, err := client.R().SetBody(&model.PostDuplicateConfigRequest{Name: newName}).Post(endpoint)
 			require.NoError(t, err)
 
 			require.Equal(t, http.StatusNotFound, resp.StatusCode())
@@ -660,7 +660,7 @@ func TestREST(t *testing.T) {
 
 		t.Run("400 Bad Request", func(t *testing.T) {
 			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
-			resp, err := client.R().SetBody(`{"""`).Put(endpoint)
+			resp, err := client.R().SetBody(`{"""`).Post(endpoint)
 			require.NoError(t, err)
 
 			require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -669,7 +669,7 @@ func TestREST(t *testing.T) {
 
 		t.Run("409 Conflict", func(t *testing.T) {
 			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
-			resp, err := client.R().SetBody(&model.PutDuplicateConfigRequest{Name: thirdName}).Put(endpoint)
+			resp, err := client.R().SetBody(&model.PostDuplicateConfigRequest{Name: thirdName}).Post(endpoint)
 			require.NoError(t, err)
 
 			require.Equal(t, http.StatusConflict, resp.StatusCode())
@@ -677,9 +677,9 @@ func TestREST(t *testing.T) {
 
 		t.Run("201 Created", func(t *testing.T) {
 			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
-			result := &model.PutDuplicateConfigResponse{}
+			result := &model.PostDuplicateConfigResponse{}
 
-			resp, err := client.R().SetBody(&model.PutDuplicateConfigRequest{Name: newName}).SetResult(result).Put(endpoint)
+			resp, err := client.R().SetBody(&model.PostDuplicateConfigRequest{Name: newName}).SetResult(result).Post(endpoint)
 			require.NoError(t, err)
 
 			require.Equal(t, http.StatusCreated, resp.StatusCode())

--- a/internal/rest/api_test.go
+++ b/internal/rest/api_test.go
@@ -638,6 +638,55 @@ func TestREST(t *testing.T) {
 		assert.NotContains(t, configurations, testConfiguration1)
 	})
 
+	t.Run("PUT /configurations/:name/duplicate", func(t *testing.T) {
+		resetStore(t, s)
+		originalName := "original"
+		newName := "newName"
+		thirdName := "third"
+
+		original := testConfiguration(originalName)
+		third := testConfiguration(thirdName)
+		_, err := bindplane.Store().ApplyResources([]model.Resource{original, third})
+		require.NoError(t, err)
+
+		t.Run("404 Not Found", func(t *testing.T) {
+			endpoint := "/configurations/does-not-exist/duplicate"
+
+			resp, err := client.R().SetBody(&model.PutDuplicateConfigRequest{Name: newName}).Put(endpoint)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusNotFound, resp.StatusCode())
+		})
+
+		t.Run("400 Bad Request", func(t *testing.T) {
+			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
+			resp, err := client.R().SetBody(`{"""`).Put(endpoint)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode())
+
+		})
+
+		t.Run("409 Conflict", func(t *testing.T) {
+			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
+			resp, err := client.R().SetBody(&model.PutDuplicateConfigRequest{Name: thirdName}).Put(endpoint)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusConflict, resp.StatusCode())
+		})
+
+		t.Run("201 Created", func(t *testing.T) {
+			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
+			result := &model.PutDuplicateConfigResponse{}
+
+			resp, err := client.R().SetBody(&model.PutDuplicateConfigRequest{Name: newName}).SetResult(result).Put(endpoint)
+			require.NoError(t, err)
+
+			require.Equal(t, http.StatusCreated, resp.StatusCode())
+			require.Equal(t, result.Name, newName)
+		})
+	})
+
 	t.Run("POST /delete Status 200 Accepted", func(t *testing.T) {
 		tests := []struct {
 			description   string

--- a/model/configuration.go
+++ b/model/configuration.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 	"github.com/observiq/bindplane-op/internal/store/search"
 	"github.com/observiq/bindplane-op/model/otel"
@@ -487,16 +488,14 @@ func (rc *ResourceConfiguration) indexFields(resourceName string, resourceTypeNa
 // a duplicate with the new name.  It should be identical except for the
 // Metadata.Name, Metadata.ID, and Spec.Selector fields.
 func (c *Configuration) Duplicate(name string) *Configuration {
-	new := &Configuration{}
-	*new = *c
+	copy := *c
 
 	// Change the metadata values
-	new.Metadata.Name = name
-	new.Metadata.ID = name
+	copy.Metadata.Name = name
+	copy.Metadata.ID = uuid.NewString()
 
-	// Replace the configuration matchLabel if present
-
-	matchLabels := new.Spec.Selector.MatchLabels
+	// replace the configuration matchLabel
+	matchLabels := copy.Spec.Selector.MatchLabels
 	matchLabels["configuration"] = name
-	return new
+	return &copy
 }

--- a/model/configuration.go
+++ b/model/configuration.go
@@ -482,3 +482,21 @@ func (rc *ResourceConfiguration) indexFields(resourceName string, resourceTypeNa
 	index(resourceName, rc.Name)
 	index(resourceTypeName, rc.Type)
 }
+
+// Duplicate copies the value of the current configuration and returns
+// a duplicate with the new name.  It should be identical except for the
+// Metadata.Name, Metadata.ID, and Spec.Selector fields.
+func (c *Configuration) Duplicate(name string) *Configuration {
+	new := &Configuration{}
+	*new = *c
+
+	// Change the metadata values
+	new.Metadata.Name = name
+	new.Metadata.ID = name
+
+	// Replace the configuration matchLabel if present
+
+	matchLabels := new.Spec.Selector.MatchLabels
+	matchLabels["configuration"] = name
+	return new
+}

--- a/model/configuration_test.go
+++ b/model/configuration_test.go
@@ -543,9 +543,13 @@ func TestDuplicate(t *testing.T) {
 	})
 
 	t.Run("replace name, id, and match labels", func(t *testing.T) {
+		// Set the duplicate name
 		require.Equal(t, new.Metadata.Name, duplicateName)
-		require.Equal(t, new.Metadata.ID, duplicateName)
 
+		// Set a new ID
+		require.NotEqual(t, new.Metadata.ID, configuration.Metadata.ID)
+
+		// Set the configuration matchLabel
 		require.Contains(t, new.Spec.Selector.MatchLabels, "configuration")
 		require.Equal(t, new.Spec.Selector.MatchLabels["configuration"], duplicateName)
 	})

--- a/model/configuration_test.go
+++ b/model/configuration_test.go
@@ -527,3 +527,26 @@ func TestEvalConfigurationFailsMissingResource(t *testing.T) {
 		})
 	}
 }
+
+func TestDuplicate(t *testing.T) {
+	duplicateName := "duplicate-config"
+
+	configuration := testResource[*Configuration](t, "configuration-macos-googlecloud.yaml")
+	require.NotNil(t, configuration)
+
+	new := configuration.Duplicate(duplicateName)
+	require.NotNil(t, new)
+
+	t.Run("equal sources, destinations", func(t *testing.T) {
+		require.Equal(t, configuration.Spec.Sources, new.Spec.Sources)
+		require.Equal(t, configuration.Spec.Destinations, new.Spec.Destinations)
+	})
+
+	t.Run("replace name, id, and match labels", func(t *testing.T) {
+		require.Equal(t, new.Metadata.Name, duplicateName)
+		require.Equal(t, new.Metadata.ID, duplicateName)
+
+		require.Contains(t, new.Spec.Selector.MatchLabels, "configuration")
+		require.Equal(t, new.Spec.Selector.MatchLabels["configuration"], duplicateName)
+	})
+}

--- a/model/rest.go
+++ b/model/rest.go
@@ -172,11 +172,11 @@ type PostAgentVersionRequest struct {
 	Version string `json:"version"`
 }
 
-// PutDuplicateConfigRequest is the REST API body for PUT /v1/configurations/{name}/duplicate
-type PutDuplicateConfigRequest struct {
+// PostDuplicateConfigRequest is the REST API body for PUT /v1/configurations/{name}/duplicate
+type PostDuplicateConfigRequest struct {
 	// The intended name of the duplicated config
 	Name string `json:"name"`
 }
 
-// PutDuplicateConfigResponse is the REST API response to PUT /v1/configurations/{name}/duplicate
-type PutDuplicateConfigResponse = PutDuplicateConfigRequest
+// PostDuplicateConfigResponse is the REST API response to PUT /v1/configurations/{name}/duplicate
+type PostDuplicateConfigResponse = PostDuplicateConfigRequest

--- a/model/rest.go
+++ b/model/rest.go
@@ -171,3 +171,12 @@ type InstallCommandResponse struct {
 type PostAgentVersionRequest struct {
 	Version string `json:"version"`
 }
+
+// PutDuplicateConfigRequest is the REST API body for PUT /v1/configurations/{name}/duplicate
+type PutDuplicateConfigRequest struct {
+	// The intended name of the duplicated config
+	Name string `json:"name"`
+}
+
+// PutDuplicateConfigResponse is the REST API response to PUT /v1/configurations/{name}/duplicate
+type PutDuplicateConfigResponse = PutDuplicateConfigRequest

--- a/ui/src/pages/configurations/configuration/DetailsSection.tsx
+++ b/ui/src/pages/configurations/configuration/DetailsSection.tsx
@@ -26,6 +26,7 @@ import { useNavigate } from "react-router-dom";
 
 import styles from "./configuration-page.module.scss";
 import mixins from "../../../styles/mixins.module.scss";
+import { DuplicateConfigDialog } from "./DuplicateConfigDialog";
 
 const DetailsSectionComponent: React.FC<{
   configuration: NonNullable<ShowPageConfig>;
@@ -38,6 +39,7 @@ const DetailsSectionComponent: React.FC<{
   onSaveDescriptionError,
   onSaveDescriptionSuccess,
 }) => {
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
   const [openDeleteConfirm, setOpenDelete] = useState(false);
   const [editingDescription, setEditingDescription] = useState(false);
   const descriptionInputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -104,13 +106,22 @@ const DetailsSectionComponent: React.FC<{
         <Typography variant="h5" marginBottom="1rem">
           Details
         </Typography>
-        <Button
-          color="error"
-          variant="contained"
-          onClick={() => setOpenDelete(true)}
-        >
-          Delete
-        </Button>
+        <Stack direction="row" spacing={2}>
+          <Button
+            variant="outlined"
+            onClick={() => setDuplicateDialogOpen(true)}
+          >
+            Duplicate
+          </Button>
+
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => setOpenDelete(true)}
+          >
+            Delete
+          </Button>
+        </Stack>
       </Stack>
 
       {/* Agent Details Table */}
@@ -188,7 +199,6 @@ const DetailsSectionComponent: React.FC<{
           </CardContent>
         </Card>
       </div>
-
       <ConfirmDeleteResourceDialog
         open={openDeleteConfirm}
         onCancel={() => setOpenDelete(false)}
@@ -199,6 +209,13 @@ const DetailsSectionComponent: React.FC<{
           Are you sure you want to delete this configuration?
         </Typography>
       </ConfirmDeleteResourceDialog>
+
+      <DuplicateConfigDialog
+        currentConfigName={configuration.metadata.name}
+        open={duplicateDialogOpen}
+        onClose={() => setDuplicateDialogOpen(false)}
+        maxWidth="xs"
+      />
     </CardContainer>
   );
 };

--- a/ui/src/pages/configurations/configuration/DuplicateConfigDialog.test.tsx
+++ b/ui/src/pages/configurations/configuration/DuplicateConfigDialog.test.tsx
@@ -1,0 +1,41 @@
+import { ApolloProvider } from "@apollo/client";
+import { render, screen } from "@testing-library/react";
+import { SnackbarProvider } from "notistack";
+import { MemoryRouter } from "react-router-dom";
+import APOLLO_CLIENT from "../../../apollo-client";
+import { DuplicateConfigDialog } from "./DuplicateConfigDialog";
+
+describe("DuplicateConfigDialog", () => {
+  it("renders without error", () => {
+    render(
+      <SnackbarProvider>
+        <ApolloProvider client={APOLLO_CLIENT}>
+          <MemoryRouter>
+            <DuplicateConfigDialog
+              open={true}
+              currentConfigName={"current-config-name"}
+            />
+          </MemoryRouter>
+        </ApolloProvider>
+      </SnackbarProvider>
+    );
+  });
+
+  it("disables save button by default", () => {
+    render(
+      <SnackbarProvider>
+        <ApolloProvider client={APOLLO_CLIENT}>
+          <MemoryRouter>
+            <DuplicateConfigDialog
+              open={true}
+              currentConfigName={"current-config-name"}
+            />
+          </MemoryRouter>
+        </ApolloProvider>
+      </SnackbarProvider>
+    );
+
+    const saveButton = screen.getByText("Save");
+    expect(saveButton).toBeDisabled();
+  });
+});

--- a/ui/src/pages/configurations/configuration/DuplicateConfigDialog.tsx
+++ b/ui/src/pages/configurations/configuration/DuplicateConfigDialog.tsx
@@ -1,0 +1,134 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogProps,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { isFunction } from "lodash";
+import { useSnackbar } from "notistack";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useGetConfigNamesQuery } from "../../../graphql/generated";
+import { validateNameField } from "../../../utils/forms/validate-name-field";
+import { duplicateConfig } from "../../../utils/rest/duplicate-config";
+
+interface Props extends DialogProps {
+  currentConfigName: string;
+}
+
+export const DuplicateConfigDialog: React.FC<Props> = ({
+  currentConfigName,
+  ...dialogProps
+}) => {
+  const [newName, setNewName] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  const { data, error } = useGetConfigNamesQuery();
+  const configNames = data?.configurations.configurations.map(
+    (c) => c.metadata.name
+  );
+  const formError = validateNameField(newName, "configuration", configNames);
+
+  const { enqueueSnackbar } = useSnackbar();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!dialogProps.open) {
+      setTouched(false);
+      setNewName("");
+    }
+  }, [dialogProps.open]);
+
+  useEffect(() => {
+    if (error != null) {
+      const message = "Error retrieving configuration names.";
+      enqueueSnackbar(message, { key: message, variant: "error" });
+    }
+  }, [enqueueSnackbar, error]);
+
+  async function handleSave(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const status = await duplicateConfig({
+      existingName: currentConfigName,
+      newName: newName,
+    });
+
+    let message: string;
+    switch (status) {
+      case "conflict":
+        message = "Looks like a configuration with that name already exists.";
+        enqueueSnackbar(message, { key: message, variant: "warning" });
+        break;
+      case "error":
+        message = "Oops, something went wrong. Failed to duplicate.";
+        enqueueSnackbar(message, { key: message, variant: "error" });
+        break;
+      case "created":
+        message = "Successfully duplicated!";
+        enqueueSnackbar(message, { key: message, variant: "success" });
+        navigate(`/configurations/${newName}`);
+        break;
+    }
+  }
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) {
+    if (!touched) {
+      setTouched(true);
+    }
+    setNewName(e.target.value);
+  }
+
+  return (
+    <Dialog {...dialogProps}>
+      <DialogContent>
+        <Typography variant="h6" marginBottom={2}>
+          Duplicate Configuration
+        </Typography>
+        <Typography variant="body2">
+          Clicking save will create a new Configuration with identical sources
+          and destinations.
+        </Typography>
+        <form onSubmit={handleSave}>
+          <TextField
+            value={newName}
+            onChange={handleChange}
+            size="small"
+            label="Name"
+            helperText={touched && formError ? formError : undefined}
+            name="name"
+            fullWidth
+            error={touched && formError != null}
+            margin="normal"
+            required
+            onBlur={() => setTouched(true)}
+          />
+
+          <Stack direction="row" justifyContent="space-between">
+            <Button
+              color="secondary"
+              onClick={() => {
+                isFunction(dialogProps.onClose) &&
+                  dialogProps.onClose({}, "backdropClick");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              disabled={formError != null}
+              type="submit"
+            >
+              Save
+            </Button>
+          </Stack>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/ui/src/pages/configurations/configuration/index.tsx
+++ b/ui/src/pages/configurations/configuration/index.tsx
@@ -18,10 +18,10 @@ import { ConfigurationSection } from "./ConfigurationSection";
 import { SourcesSection } from "./SourcesSection";
 import { DestinationsSection } from "./DestinationsSection";
 import { useSnackbar } from "notistack";
-
-import styles from "./configuration-page.module.scss";
 import { withRequireLogin } from "../../../contexts/RequireLogin";
 import { withNavBar } from "../../../components/NavBar";
+
+import styles from "./configuration-page.module.scss";
 
 gql`
   query GetConfiguration($name: String!) {

--- a/ui/src/types/rest.ts
+++ b/ui/src/types/rest.ts
@@ -43,3 +43,9 @@ export interface LabelAgentsPayload {
 export interface LabelAgentsResponse {
   errors: string[];
 }
+
+export interface DuplicateConfigPayload {
+  name: string;
+}
+
+export type DuplicateConfigResponse = DuplicateConfigPayload;

--- a/ui/src/utils/rest/duplicate-config.test.ts
+++ b/ui/src/utils/rest/duplicate-config.test.ts
@@ -10,7 +10,7 @@ describe("duplicateConfig", () => {
     let endpointCalled = false;
     let payload: any;
     nock("http://localhost:80")
-      .put(endpoint, (body) => {
+      .post(endpoint, (body) => {
         endpointCalled = true;
         payload = body;
         return true;
@@ -27,7 +27,7 @@ describe("duplicateConfig", () => {
 
   it("created", async () => {
     nock("http://localhost:80")
-      .put("/v1/configurations/name/duplicate", (body) => {
+      .post("/v1/configurations/name/duplicate", (body) => {
         return true;
       })
       .reply(201, {
@@ -39,7 +39,7 @@ describe("duplicateConfig", () => {
   });
   it("conflict", async () => {
     nock("http://localhost:80")
-      .put("/v1/configurations/name/duplicate", (body) => {
+      .post("/v1/configurations/name/duplicate", (body) => {
         return true;
       })
       .reply(409, {});
@@ -49,7 +49,7 @@ describe("duplicateConfig", () => {
   });
   it("error", async () => {
     nock("http://localhost:80")
-      .put("/v1/configurations/name/duplicate", (body) => {
+      .post("/v1/configurations/name/duplicate", (body) => {
         return true;
       })
       .reply(500, {});

--- a/ui/src/utils/rest/duplicate-config.test.ts
+++ b/ui/src/utils/rest/duplicate-config.test.ts
@@ -1,0 +1,60 @@
+import nock from "nock";
+import { duplicateConfig } from "./duplicate-config";
+
+describe("duplicateConfig", () => {
+  const existingName = "name";
+  const newName = "new-name";
+  const endpoint = "/v1/configurations/name/duplicate";
+
+  it("correct endpoint and payload", async () => {
+    let endpointCalled = false;
+    let payload: any;
+    nock("http://localhost:80")
+      .put(endpoint, (body) => {
+        endpointCalled = true;
+        payload = body;
+        return true;
+      })
+      .reply(201, {
+        name: newName,
+      });
+
+    await duplicateConfig({ existingName, newName });
+
+    expect(endpointCalled).toEqual(true);
+    expect(payload).toEqual({ name: newName });
+  });
+
+  it("created", async () => {
+    nock("http://localhost:80")
+      .put("/v1/configurations/name/duplicate", (body) => {
+        return true;
+      })
+      .reply(201, {
+        name: "new-name",
+      });
+
+    const status = await duplicateConfig({ existingName, newName });
+    expect(status).toEqual("created");
+  });
+  it("conflict", async () => {
+    nock("http://localhost:80")
+      .put("/v1/configurations/name/duplicate", (body) => {
+        return true;
+      })
+      .reply(409, {});
+
+    const status = await duplicateConfig({ existingName, newName });
+    expect(status).toEqual("conflict");
+  });
+  it("error", async () => {
+    nock("http://localhost:80")
+      .put("/v1/configurations/name/duplicate", (body) => {
+        return true;
+      })
+      .reply(500, {});
+
+    const status = await duplicateConfig({ existingName, newName });
+    expect(status).toEqual("error");
+  });
+});

--- a/ui/src/utils/rest/duplicate-config.ts
+++ b/ui/src/utils/rest/duplicate-config.ts
@@ -1,5 +1,4 @@
 import { DuplicateConfigPayload } from "../../types/rest";
-
 export async function duplicateConfig({
   existingName,
   newName,
@@ -12,7 +11,7 @@ export async function duplicateConfig({
   };
   try {
     const resp = await fetch(`/v1/configurations/${existingName}/duplicate`, {
-      method: "PUT",
+      method: "POST",
       body: JSON.stringify(payload),
     });
 

--- a/ui/src/utils/rest/duplicate-config.ts
+++ b/ui/src/utils/rest/duplicate-config.ts
@@ -1,0 +1,30 @@
+import { DuplicateConfigPayload } from "../../types/rest";
+
+export async function duplicateConfig({
+  existingName,
+  newName,
+}: {
+  existingName: string;
+  newName: string;
+}): Promise<"created" | "conflict" | "error"> {
+  const payload: DuplicateConfigPayload = {
+    name: newName,
+  };
+  try {
+    const resp = await fetch(`/v1/configurations/${existingName}/duplicate`, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+
+    switch (resp.status) {
+      case 201:
+        return "created";
+      case 409:
+        return "conflict";
+      default:
+        return "error";
+    }
+  } catch (err) {
+    return "error";
+  }
+}


### PR DESCRIPTION
### Proposed Change
It can be useful to make a copy of an existing config if you wanted to adjust sources slightly.  

This PR:
- Adds a REST endpoint `POST /v1/configurations/:name/duplicate` will copy the `Spec` of a config into a new one, changing only the `metadata.name`, `metadata.id`, and `spec.selector.matchLabels` fields.
- Add a "Duplicate" Button on the configuration view page:
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/64915094/181260269-9f44e15a-8497-4466-aba7-3842d9fdc005.png">
<img width="841" alt="image" src="https://user-images.githubusercontent.com/64915094/181260384-f4eb4bb2-5ba1-4054-bab6-4eb289ea3c45.png">


##### Checklist
- [x] Changes are tested
- [ ] CI has passed
