### PR TITLE
Set 60 second timeout for test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test: prep
 
 .PHONY: test-with-cover
 test-with-cover: prep
-	BINDPLANE_TEST_IMAGE="observiq/bindplane-amd64:$(GIT_SHA)" go-acc --timeout 60s --tags=integration --output=coverage.out --ignore=generated --ignore=mocks ./...
+	BINDPLANE_TEST_IMAGE="observiq/bindplane-amd64:$(GIT_SHA)" go-acc --tags=integration --output=coverage.out --ignore=generated --ignore=mocks ./...
 
 show-coverage: test-with-cover
 	# Show coverage as HTML in the default browser.

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ dev:
 
 .PHONY: test
 test: prep
-	go test ./... -race -cover
+	go test ./... -race -cover -timeout 60s
 
 .PHONY: test-with-cover
 test-with-cover: prep
-	BINDPLANE_TEST_IMAGE="observiq/bindplane-amd64:$(GIT_SHA)" go-acc --tags=integration --output=coverage.out --ignore=generated --ignore=mocks ./...
+	BINDPLANE_TEST_IMAGE="observiq/bindplane-amd64:$(GIT_SHA)" go-acc --timeout 60s --tags=integration --output=coverage.out --ignore=generated --ignore=mocks ./...
 
 show-coverage: test-with-cover
 	# Show coverage as HTML in the default browser.


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

It is hard to track down flaky tests when not using a timeout. 60 seconds should be more than enough for the current tests, and short enough to catch things quicker.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
