### PR TITLE
fix: flakey store test

### DIFF
--- a/internal/eventbus/source.go
+++ b/internal/eventbus/source.go
@@ -74,6 +74,8 @@ var _ Source[any] = (*source[any])(nil)
 
 type subscription[T any] struct {
 	channel chan T
+	ctx     context.Context
+	cancel  context.CancelFunc
 }
 
 func newSubscription[T any](options []SubscriptionOption[T]) Subscriber[T] {
@@ -85,13 +87,20 @@ func newSubscription[T any](options []SubscriptionOption[T]) Subscriber[T] {
 	if channel == nil {
 		channel = make(chan T, subscriberChannelBufferSize)
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 	return &subscription[T]{
 		channel: channel,
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 }
 
 func (s *subscription[T]) Receive(event T) {
-	s.channel <- event
+	select {
+	case <-s.ctx.Done():
+		close(s.channel)
+	case s.channel <- event:
+	}
 }
 
 func (s *subscription[T]) Channel() <-chan T {
@@ -99,7 +108,7 @@ func (s *subscription[T]) Channel() <-chan T {
 }
 
 func (s *subscription[T]) Close() {
-	close(s.channel)
+	s.cancel()
 }
 
 var _ Subscriber[int] = (*subscription[int])(nil)
@@ -235,13 +244,19 @@ func (s *source[T]) SubscribeUntilDone(ctx context.Context, subscriber Subscribe
 
 // Send the event to all of the subscribers
 func (s *source[T]) Send(event T) {
-	s.mtx.RLock()
-	subscribers := s.subscribers
-	s.mtx.RUnlock()
-
-	for sub := range subscribers {
+	for _, sub := range s.subscriberList() {
 		sub.Receive(event)
 	}
+}
+
+func (s *source[T]) subscriberList() []Subscriber[T] {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	subscribers := make([]Subscriber[T], 0, len(s.subscribers))
+	for sub := range s.subscribers {
+		subscribers = append(subscribers, sub)
+	}
+	return subscribers
 }
 
 // Subscribers returns the current number of subscribers

--- a/internal/eventbus/source.go
+++ b/internal/eventbus/source.go
@@ -236,9 +236,10 @@ func (s *source[T]) SubscribeUntilDone(ctx context.Context, subscriber Subscribe
 // Send the event to all of the subscribers
 func (s *source[T]) Send(event T) {
 	s.mtx.RLock()
-	defer s.mtx.RUnlock()
+	subscribers := s.subscribers
+	s.mtx.RUnlock()
 
-	for sub := range s.subscribers {
+	for sub := range subscribers {
 		sub.Receive(event)
 	}
 }


### PR DESCRIPTION
### Proposed Change
Fix the flakey TestMapstoreDeleteAgents test

Here is the stack after timeout with the deadlock highlighted with ===>. Before iterating over subscribers, we need to unlock because Receive could block and hold the mutex.

```
goroutine 52 [running]:
testing.(*M).startAlarm.func1()
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:2029 +0x8c
created by time.goFunc
	/opt/homebrew/opt/go/libexec/src/time/sleep.go:176 +0x3c

goroutine 1 [chan receive]:
testing.(*T).Run(0x14000103040, {0x104e85712?, 0x2235a8a82f1cc?}, 0x105120ff0)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1487 +0x314
testing.runTests.func1(0x0?)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1839 +0x74
testing.tRunner(0x14000103040, 0x140006bfcb8)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1439 +0x110
testing.runTests(0x140004b20a0?, {0x10559e2a0, 0x27, 0x27}, {0x140006bfd28?, 0x1048afcac?, 0x1055aa540?})
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1837 +0x3f0
testing.(*M).Run(0x140004b20a0)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1719 +0x500
main.main()
	_testmain.go:123 +0x1d0

goroutine 4 [select]:
go.opencensus.io/stats/view.(*worker).start(0x14000188800)
	/Users/andy/go/pkg/mod/go.opencensus.io@v0.23.0/stats/view/worker.go:276 +0x88
created by go.opencensus.io/stats/view.init.0
	/Users/andy/go/pkg/mod/go.opencensus.io@v0.23.0/stats/view/worker.go:34 +0xa8

goroutine 9 [chan receive]:
testing.(*T).Run(0x140001031e0, {0x104e9d0f1?, 0x14000000fc0?}, 0x14000128720)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1487 +0x314
github.com/observiq/bindplane-op/internal/store.runDeleteAgentsTests(0x10512e458?, {0x1051338a8?, 0x140005be3c0})
	/Users/andy/bindplane/iris/internal/store/store_test.go:1091 +0x8f8
github.com/observiq/bindplane-op/internal/store.TestMapstoreDeleteAgents(0x0?)
	/Users/andy/bindplane/iris/internal/store/mapstore_test.go:166 +0x1a0
testing.tRunner(0x140001031e0, 0x105120ff0)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1486 +0x300

goroutine 10 [sleep]:
time.Sleep(0x5f5e100)
	/opt/homebrew/opt/go/libexec/src/runtime/time.go:194 +0x11c
github.com/observiq/bindplane-op/internal/util.(*unboundedChan[...]).send(0x14000112880)
	/Users/andy/bindplane/iris/internal/util/unbounded.go:78 +0x5c
created by github.com/observiq/bindplane-op/internal/util.NewUnboundedChan[...]
	/Users/andy/bindplane/iris/internal/util/unbounded.go:124 +0xfc

goroutine 11 [chan receive]:
github.com/observiq/bindplane-op/internal/util.(*unboundedChan[...]).receive(0x14000112880)
	/Users/andy/bindplane/iris/internal/util/unbounded.go:57 +0x4c
created by github.com/observiq/bindplane-op/internal/util.NewUnboundedChan[...]
	/Users/andy/bindplane/iris/internal/util/unbounded.go:125 +0x154

goroutine 12 [chan send]:
===> github.com/observiq/bindplane-op/internal/eventbus.(*subscription[...]).Receive(...)
	/Users/andy/bindplane/iris/internal/eventbus/source.go:94
github.com/observiq/bindplane-op/internal/eventbus.(*source[...]).Send(0x105910a90?, 0x1400007adf8?)
	/Users/andy/bindplane/iris/internal/eventbus/source.go:242 +0xec
github.com/observiq/bindplane-op/internal/eventbus.RelayWithMerge[...].func1.1()
	/Users/andy/bindplane/iris/internal/eventbus/source.go:324 +0x1b8
github.com/observiq/bindplane-op/internal/eventbus.RelayWithMerge[...].func1()
	/Users/andy/bindplane/iris/internal/eventbus/source.go:341 +0x218
created by github.com/observiq/bindplane-op/internal/eventbus.RelayWithMerge[...]
	/Users/andy/bindplane/iris/internal/eventbus/source.go:298 +0x164

goroutine 50 [semacquire]:
sync.runtime_SemacquireMutex(0x105033960?, 0xf0?, 0x104e3e3d4?)
	/opt/homebrew/opt/go/libexec/src/runtime/sema.go:71 +0x28
sync.(*RWMutex).Lock(0x14000114300?)
	/opt/homebrew/opt/go/libexec/src/sync/rwmutex.go:144 +0x110
===> github.com/observiq/bindplane-op/internal/eventbus.(*source[...]).SubscribeUntilDone.func1()
	/Users/andy/bindplane/iris/internal/eventbus/source.go:219 +0x4c
github.com/observiq/bindplane-op/internal/store.runDeleteAgentsTests.func3(0x1400058ed00)
	/Users/andy/bindplane/iris/internal/store/store_test.go:1110 +0x22c
testing.tRunner(0x1400058ed00, 0x14000128720)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1486 +0x300
FAIL	github.com/observiq/bindplane-op/internal/store	30.136s
FAIL
```


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
