### PR TITLE
fix: Change verifyAgentsRemove to fix flakey tests

### DIFF
--- a/internal/eventbus/source_test.go
+++ b/internal/eventbus/source_test.go
@@ -356,12 +356,12 @@ func TestEventBusRelay(t *testing.T) {
 
 			Relay(ctx, src, dst)
 
+			channel, unsubscribe := Subscribe(dst)
+			defer unsubscribe()
+
 			for _, event := range test.events {
 				src.Send(event)
 			}
-
-			channel, unsubscribe := Subscribe(dst)
-			defer unsubscribe()
 
 			for i := 0; i < len(test.events); i++ {
 				val := <-channel
@@ -394,12 +394,12 @@ func TestEventBusRelayWithFilter(t *testing.T) {
 
 			RelayWithFilter(ctx, src, func(val int) (int, bool) { return val * 2, true }, dst)
 
+			channel, unsubscribe := Subscribe(dst)
+			defer unsubscribe()
+
 			for _, event := range test.events {
 				src.Send(event)
 			}
-
-			channel, unsubscribe := Subscribe(dst)
-			defer unsubscribe()
 
 			for i := 0; i < len(test.events); i++ {
 				val := <-channel


### PR DESCRIPTION
### Proposed Change
* Changes verifyAgentsRemove to only verify that the agents we expect to see remove events for are included and ignore extra events
* Updates EventBus source tests to subscribe before sending to avoid timing issues (similar to #134)

##### Checklist
- [ ] Changes are tested
- [x] CI has passed
