### PR TITLE
feat: Parameter option "creatable" for enum parameter.

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -62,6 +62,9 @@ models:
   ParameterInput:
     model:
       - github.com/observiq/bindplane-op/model.Parameter
+  ParameterOptions:
+    model:
+      - github.com/observiq/bindplane-op/model.ParameterOptions
   PipelineType:
     model:
       - github.com/observiq/bindplane-op/model/otel.PipelineType

--- a/internal/graphql/generated/server_gen.go
+++ b/internal/graphql/generated/server_gen.go
@@ -168,6 +168,7 @@ type ComplexityRoot struct {
 	}
 
 	ParameterDefinition struct {
+		Creatable   func(childComplexity int) int
 		Default     func(childComplexity int) int
 		Description func(childComplexity int) int
 		Label       func(childComplexity int) int
@@ -770,6 +771,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Parameter.Value(childComplexity), true
+
+	case "ParameterDefinition.creatable":
+		if e.complexity.ParameterDefinition.Creatable == nil {
+			break
+		}
+
+		return e.complexity.ParameterDefinition.Creatable(childComplexity), true
 
 	case "ParameterDefinition.default":
 		if e.complexity.ParameterDefinition.Default == nil {
@@ -1520,6 +1528,7 @@ type ParameterDefinition {
   type: ParameterType!
 
   validValues: [String!]
+  creatable: Boolean!
 
   default: Any
   relevantIf: [RelevantIfCondition!]
@@ -5008,6 +5017,50 @@ func (ec *executionContext) fieldContext_ParameterDefinition_validValues(ctx con
 	return fc, nil
 }
 
+func (ec *executionContext) _ParameterDefinition_creatable(ctx context.Context, field graphql.CollectedField, obj *model.ParameterDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ParameterDefinition_creatable(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Creatable, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ParameterDefinition_creatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ParameterDefinition",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ParameterDefinition_default(ctx context.Context, field graphql.CollectedField, obj *model.ParameterDefinition) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ParameterDefinition_default(ctx, field)
 	if err != nil {
@@ -7206,6 +7259,8 @@ func (ec *executionContext) fieldContext_ResourceTypeSpec_parameters(ctx context
 				return ec.fieldContext_ParameterDefinition_type(ctx, field)
 			case "validValues":
 				return ec.fieldContext_ParameterDefinition_validValues(ctx, field)
+			case "creatable":
+				return ec.fieldContext_ParameterDefinition_creatable(ctx, field)
 			case "default":
 				return ec.fieldContext_ParameterDefinition_default(ctx, field)
 			case "relevantIf":
@@ -10539,6 +10594,13 @@ func (ec *executionContext) _ParameterDefinition(ctx context.Context, sel ast.Se
 
 			out.Values[i] = ec._ParameterDefinition_validValues(ctx, field, obj)
 
+		case "creatable":
+
+			out.Values[i] = ec._ParameterDefinition_creatable(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "default":
 
 			out.Values[i] = ec._ParameterDefinition_default(ctx, field, obj)
@@ -11918,12 +11980,12 @@ func (ec *executionContext) marshalNAgents2ᚖgithubᚗcomᚋobserviqᚋbindplan
 	return ec._Agents(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNAny2interface(ctx context.Context, v interface{}) (any, error) {
+func (ec *executionContext) unmarshalNAny2interface(ctx context.Context, v interface{}) (interface{}, error) {
 	res, err := graphql.UnmarshalAny(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNAny2interface(ctx context.Context, sel ast.SelectionSet, v any) graphql.Marshaler {
+func (ec *executionContext) marshalNAny2interface(ctx context.Context, sel ast.SelectionSet, v interface{}) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/internal/graphql/generated/server_gen.go
+++ b/internal/graphql/generated/server_gen.go
@@ -168,15 +168,19 @@ type ComplexityRoot struct {
 	}
 
 	ParameterDefinition struct {
-		Creatable   func(childComplexity int) int
 		Default     func(childComplexity int) int
 		Description func(childComplexity int) int
 		Label       func(childComplexity int) int
 		Name        func(childComplexity int) int
+		Options     func(childComplexity int) int
 		RelevantIf  func(childComplexity int) int
 		Required    func(childComplexity int) int
 		Type        func(childComplexity int) int
 		ValidValues func(childComplexity int) int
+	}
+
+	ParameterOptions struct {
+		Creatable func(childComplexity int) int
 	}
 
 	ParameterizedSpec struct {
@@ -772,13 +776,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Parameter.Value(childComplexity), true
 
-	case "ParameterDefinition.creatable":
-		if e.complexity.ParameterDefinition.Creatable == nil {
-			break
-		}
-
-		return e.complexity.ParameterDefinition.Creatable(childComplexity), true
-
 	case "ParameterDefinition.default":
 		if e.complexity.ParameterDefinition.Default == nil {
 			break
@@ -807,6 +804,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ParameterDefinition.Name(childComplexity), true
 
+	case "ParameterDefinition.options":
+		if e.complexity.ParameterDefinition.Options == nil {
+			break
+		}
+
+		return e.complexity.ParameterDefinition.Options(childComplexity), true
+
 	case "ParameterDefinition.relevantIf":
 		if e.complexity.ParameterDefinition.RelevantIf == nil {
 			break
@@ -834,6 +838,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ParameterDefinition.ValidValues(childComplexity), true
+
+	case "ParameterOptions.creatable":
+		if e.complexity.ParameterOptions.Creatable == nil {
+			break
+		}
+
+		return e.complexity.ParameterOptions.Creatable(childComplexity), true
 
 	case "ParameterizedSpec.parameters":
 		if e.complexity.ParameterizedSpec.Parameters == nil {
@@ -1528,10 +1539,15 @@ type ParameterDefinition {
   type: ParameterType!
 
   validValues: [String!]
-  creatable: Boolean!
 
   default: Any
   relevantIf: [RelevantIfCondition!]
+
+  options: ParameterOptions!
+}
+
+type ParameterOptions {
+  creatable: Boolean
 }
 
 type RelevantIfCondition {
@@ -5017,50 +5033,6 @@ func (ec *executionContext) fieldContext_ParameterDefinition_validValues(ctx con
 	return fc, nil
 }
 
-func (ec *executionContext) _ParameterDefinition_creatable(ctx context.Context, field graphql.CollectedField, obj *model.ParameterDefinition) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ParameterDefinition_creatable(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Creatable, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ParameterDefinition_creatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ParameterDefinition",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _ParameterDefinition_default(ctx context.Context, field graphql.CollectedField, obj *model.ParameterDefinition) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ParameterDefinition_default(ctx, field)
 	if err != nil {
@@ -5146,6 +5118,95 @@ func (ec *executionContext) fieldContext_ParameterDefinition_relevantIf(ctx cont
 				return ec.fieldContext_RelevantIfCondition_value(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RelevantIfCondition", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ParameterDefinition_options(ctx context.Context, field graphql.CollectedField, obj *model.ParameterDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ParameterDefinition_options(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Options, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ParameterOptions)
+	fc.Result = res
+	return ec.marshalNParameterOptions2githubᚗcomᚋobserviqᚋbindplaneᚑopᚋmodelᚐParameterOptions(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ParameterDefinition_options(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ParameterDefinition",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "creatable":
+				return ec.fieldContext_ParameterOptions_creatable(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ParameterOptions", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ParameterOptions_creatable(ctx context.Context, field graphql.CollectedField, obj *model.ParameterOptions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ParameterOptions_creatable(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Creatable, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ParameterOptions_creatable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ParameterOptions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -7259,12 +7320,12 @@ func (ec *executionContext) fieldContext_ResourceTypeSpec_parameters(ctx context
 				return ec.fieldContext_ParameterDefinition_type(ctx, field)
 			case "validValues":
 				return ec.fieldContext_ParameterDefinition_validValues(ctx, field)
-			case "creatable":
-				return ec.fieldContext_ParameterDefinition_creatable(ctx, field)
 			case "default":
 				return ec.fieldContext_ParameterDefinition_default(ctx, field)
 			case "relevantIf":
 				return ec.fieldContext_ParameterDefinition_relevantIf(ctx, field)
+			case "options":
+				return ec.fieldContext_ParameterDefinition_options(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ParameterDefinition", field.Name)
 		},
@@ -10594,13 +10655,6 @@ func (ec *executionContext) _ParameterDefinition(ctx context.Context, sel ast.Se
 
 			out.Values[i] = ec._ParameterDefinition_validValues(ctx, field, obj)
 
-		case "creatable":
-
-			out.Values[i] = ec._ParameterDefinition_creatable(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "default":
 
 			out.Values[i] = ec._ParameterDefinition_default(ctx, field, obj)
@@ -10608,6 +10662,38 @@ func (ec *executionContext) _ParameterDefinition(ctx context.Context, sel ast.Se
 		case "relevantIf":
 
 			out.Values[i] = ec._ParameterDefinition_relevantIf(ctx, field, obj)
+
+		case "options":
+
+			out.Values[i] = ec._ParameterDefinition_options(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var parameterOptionsImplementors = []string{"ParameterOptions"}
+
+func (ec *executionContext) _ParameterOptions(ctx context.Context, sel ast.SelectionSet, obj *model.ParameterOptions) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, parameterOptionsImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ParameterOptions")
+		case "creatable":
+
+			out.Values[i] = ec._ParameterOptions_creatable(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -11980,12 +12066,12 @@ func (ec *executionContext) marshalNAgents2ᚖgithubᚗcomᚋobserviqᚋbindplan
 	return ec._Agents(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNAny2interface(ctx context.Context, v interface{}) (interface{}, error) {
+func (ec *executionContext) unmarshalNAny2interface(ctx context.Context, v interface{}) (any, error) {
 	res, err := graphql.UnmarshalAny(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNAny2interface(ctx context.Context, sel ast.SelectionSet, v interface{}) graphql.Marshaler {
+func (ec *executionContext) marshalNAny2interface(ctx context.Context, sel ast.SelectionSet, v any) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
@@ -12372,6 +12458,10 @@ func (ec *executionContext) marshalNParameterDefinition2ᚕgithubᚗcomᚋobserv
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNParameterOptions2githubᚗcomᚋobserviqᚋbindplaneᚑopᚋmodelᚐParameterOptions(ctx context.Context, sel ast.SelectionSet, v model.ParameterOptions) graphql.Marshaler {
+	return ec._ParameterOptions(ctx, sel, &v)
 }
 
 func (ec *executionContext) unmarshalNParameterType2githubᚗcomᚋobserviqᚋbindplaneᚑopᚋinternalᚋgraphqlᚋmodelᚐParameterType(ctx context.Context, v interface{}) (model1.ParameterType, error) {

--- a/internal/graphql/schema.graphqls
+++ b/internal/graphql/schema.graphqls
@@ -200,6 +200,7 @@ type ParameterDefinition {
   type: ParameterType!
 
   validValues: [String!]
+  creatable: Boolean
 
   default: Any
   relevantIf: [RelevantIfCondition!]

--- a/internal/graphql/schema.graphqls
+++ b/internal/graphql/schema.graphqls
@@ -200,10 +200,15 @@ type ParameterDefinition {
   type: ParameterType!
 
   validValues: [String!]
-  creatable: Boolean
 
   default: Any
   relevantIf: [RelevantIfCondition!]
+
+  options: ParameterOptions!
+}
+
+type ParameterOptions {
+  creatable: Boolean
 }
 
 type RelevantIfCondition {

--- a/model/parameter.go
+++ b/model/parameter.go
@@ -60,7 +60,7 @@ type ParameterDefinition struct {
 	Options ParameterOptions `json:"options" yaml:"options"`
 }
 
-// ParameterOptions specify further customization for inputs in the UI
+// ParameterOptions specify further customization for input parameters
 type ParameterOptions struct {
 	// Creatable will modify the "enum" parameter from a select to
 	// a creatable select where a user can specify a custom value

--- a/model/parameter_test.go
+++ b/model/parameter_test.go
@@ -157,6 +157,56 @@ func TestValidateDefault(t *testing.T) {
 	}
 }
 
+func TestValidateCreatable(t *testing.T) {
+	testCases := []struct {
+		name      string
+		expectErr bool
+		param     ParameterDefinition
+	}{
+		{
+			"Enum Creatable OK",
+			false,
+			ParameterDefinition{
+				Type:      "enum",
+				Creatable: true,
+			},
+		},
+		{
+			"Enum Not Createable OK",
+			false,
+			ParameterDefinition{
+				Type:      "enum",
+				Creatable: false,
+			},
+		},
+		{
+			"Non-Enum Creatable Error",
+			true,
+			ParameterDefinition{
+				Type:      "string",
+				Creatable: true,
+			},
+		},
+		{
+			"Non-Enum Not Creatable OK",
+			false,
+			ParameterDefinition{
+				Type:      "enum",
+				Creatable: true,
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		err := test.param.validateCreatable()
+		if test.expectErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}
+
 func TestValidateValue(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -263,6 +313,16 @@ func TestValidateValue(t *testing.T) {
 				Default:     "test",
 			},
 			"test",
+		},
+		{
+			"ValidEnum - Createable",
+			false,
+			ParameterDefinition{
+				Type:        "enum",
+				ValidValues: []string{"test"},
+				Creatable:   true,
+			},
+			"not-test",
 		},
 		{
 			"InvalidEnumValue",

--- a/model/parameter_test.go
+++ b/model/parameter_test.go
@@ -157,7 +157,7 @@ func TestValidateDefault(t *testing.T) {
 	}
 }
 
-func TestValidateCreatable(t *testing.T) {
+func TestValidateOptions(t *testing.T) {
 	testCases := []struct {
 		name      string
 		expectErr bool
@@ -167,38 +167,46 @@ func TestValidateCreatable(t *testing.T) {
 			"Enum Creatable OK",
 			false,
 			ParameterDefinition{
-				Type:      "enum",
-				Creatable: true,
+				Type: "enum",
+				Options: ParameterOptions{
+					Creatable: true,
+				},
 			},
 		},
 		{
-			"Enum Not Createable OK",
+			"Enum Not Creatable OK",
 			false,
 			ParameterDefinition{
-				Type:      "enum",
-				Creatable: false,
+				Type: "enum",
+				Options: ParameterOptions{
+					Creatable: false,
+				},
 			},
 		},
 		{
 			"Non-Enum Creatable Error",
 			true,
 			ParameterDefinition{
-				Type:      "string",
-				Creatable: true,
+				Type: "string",
+				Options: ParameterOptions{
+					Creatable: true,
+				},
 			},
 		},
 		{
 			"Non-Enum Not Creatable OK",
 			false,
 			ParameterDefinition{
-				Type:      "enum",
-				Creatable: true,
+				Type: "enum",
+				Options: ParameterOptions{
+					Creatable: true,
+				},
 			},
 		},
 	}
 
 	for _, test := range testCases {
-		err := test.param.validateCreatable()
+		err := test.param.validateOptions()
 		if test.expectErr {
 			require.Error(t, err)
 		} else {
@@ -315,12 +323,14 @@ func TestValidateValue(t *testing.T) {
 			"test",
 		},
 		{
-			"ValidEnum - Createable",
+			"ValidEnum - Creatable",
 			false,
 			ParameterDefinition{
 				Type:        "enum",
 				ValidValues: []string{"test"},
-				Creatable:   true,
+				Options: ParameterOptions{
+					Creatable: true,
+				},
 			},
 			"not-test",
 		},

--- a/model/testfiles/sourcetype-experimental-parameters.yaml
+++ b/model/testfiles/sourcetype-experimental-parameters.yaml
@@ -10,6 +10,15 @@ spec:
   supportedPlatforms:
     - macos
   parameters:
+    - name: creatable_enum_param
+      type: enum
+      description: BYOV - bring your own value
+      creatable: true
+      validValues:
+        - one
+        - two
+        - three
+        - four
     - name: enums_type_param
       label: Enums Param
       type: enums

--- a/model/testfiles/sourcetype-experimental-parameters.yaml
+++ b/model/testfiles/sourcetype-experimental-parameters.yaml
@@ -12,13 +12,16 @@ spec:
   parameters:
     - name: creatable_enum_param
       type: enum
-      description: BYOV - bring your own value
-      creatable: true
+      label: Creatable Enum
+      required: true
+      description: '"BYOV" - bring your own value.'
       validValues:
         - one
         - two
         - three
         - four
+      options:
+        creatable: true
     - name: enums_type_param
       label: Enums Param
       type: enums

--- a/ui/src/components/ResourceTypeForm/ParameterInput.tsx
+++ b/ui/src/components/ResourceTypeForm/ParameterInput.tsx
@@ -90,7 +90,7 @@ export const StringParamInput: React.FC<ParamInputProps<string>> = ({
 };
 
 export const EnumParamInput: React.FC<ParamInputProps<string>> = (props) => {
-  return props.definition.creatable ? (
+  return props.definition.options.creatable ? (
     <CreatableSelectInput {...props} />
   ) : (
     <SelectParamInput {...props} />
@@ -132,16 +132,16 @@ const filter = createFilterOptions<string>();
 const CreatableSelectInput: React.FC<ParamInputProps<string>> = ({
   classes,
   definition,
-  // value,
+  value,
   onValueChange,
 }) => {
-  const [value, setValue] = useState("");
-
   return (
     <Autocomplete
       value={value}
       onChange={(event, newValue) => {
-        if (newValue) setValue(newValue);
+        if (newValue && isFunction(onValueChange)) {
+          onValueChange(newValue);
+        }
       }}
       filterOptions={(options, params) => {
         const filtered = filter(options, params);
@@ -158,14 +158,20 @@ const CreatableSelectInput: React.FC<ParamInputProps<string>> = ({
       selectOnFocus
       clearOnBlur
       handleHomeEndKeys
-      id="free-solo-with-text-demo"
       options={definition.validValues ?? []}
       getOptionLabel={(option) => option}
       renderOption={(props, option) => <li {...props}>{option}</li>}
-      sx={{ width: 300 }}
       freeSolo
       renderInput={(params) => (
-        <TextField {...params} label="Free solo with text demo" />
+        <TextField
+          {...params}
+          classes={classes}
+          fullWidth
+          label={definition.label}
+          helperText={definition.description}
+          required={definition.required}
+          size="small"
+        />
       )}
     />
   );

--- a/ui/src/components/ResourceTypeForm/ParameterInput.tsx
+++ b/ui/src/components/ResourceTypeForm/ParameterInput.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Chip,
+  createFilterOptions,
   FormControl,
   FormControlLabel,
   FormHelperText,
@@ -88,7 +89,15 @@ export const StringParamInput: React.FC<ParamInputProps<string>> = ({
   );
 };
 
-export const EnumParamInput: React.FC<ParamInputProps<string>> = ({
+export const EnumParamInput: React.FC<ParamInputProps<string>> = (props) => {
+  return props.definition.creatable ? (
+    <CreatableSelectInput {...props} />
+  ) : (
+    <SelectParamInput {...props} />
+  );
+};
+
+const SelectParamInput: React.FC<ParamInputProps<string>> = ({
   classes,
   definition,
   value,
@@ -116,6 +125,49 @@ export const EnumParamInput: React.FC<ParamInputProps<string>> = ({
         </option>
       ))}
     </TextField>
+  );
+};
+
+const filter = createFilterOptions<string>();
+const CreatableSelectInput: React.FC<ParamInputProps<string>> = ({
+  classes,
+  definition,
+  // value,
+  onValueChange,
+}) => {
+  const [value, setValue] = useState("");
+
+  return (
+    <Autocomplete
+      value={value}
+      onChange={(event, newValue) => {
+        if (newValue) setValue(newValue);
+      }}
+      filterOptions={(options, params) => {
+        const filtered = filter(options, params);
+
+        const { inputValue } = params;
+        // Suggest the creation of a new value
+        const isExisting = options.some((option) => inputValue === option);
+        if (inputValue !== "" && !isExisting) {
+          filtered.push(inputValue);
+        }
+
+        return filtered;
+      }}
+      selectOnFocus
+      clearOnBlur
+      handleHomeEndKeys
+      id="free-solo-with-text-demo"
+      options={definition.validValues ?? []}
+      getOptionLabel={(option) => option}
+      renderOption={(props, option) => <li {...props}>{option}</li>}
+      sx={{ width: 300 }}
+      freeSolo
+      renderInput={(params) => (
+        <TextField {...params} label="Free solo with text demo" />
+      )}
+    />
   );
 };
 

--- a/ui/src/components/ResourceTypeForm/ResourceForm.test.tsx
+++ b/ui/src/components/ResourceTypeForm/ResourceForm.test.tsx
@@ -27,6 +27,7 @@ describe("satisfiesRelevantIf", () => {
     label: "String Input",
     description: "Here is the description.",
     required: false,
+    options: {},
 
     type: ParameterType.String,
 
@@ -44,6 +45,7 @@ describe("satisfiesRelevantIf", () => {
     label: "String Input",
     description: "Here is the description.",
     required: false,
+    options: {},
 
     type: ParameterType.String,
     relevantIf: [
@@ -200,6 +202,7 @@ describe("ResourceForm component", () => {
         type: ParameterType.Strings,
         required: true,
         description: "",
+        options: {},
       },
     ];
 
@@ -229,6 +232,7 @@ describe("ResourceForm component", () => {
       description: "description",
       type: ParameterType.Map,
       name: "map_type_param",
+      options: {},
     };
 
     it("disables save button initially if required", () => {
@@ -272,6 +276,7 @@ describe("MapParamInput", () => {
     description: "description",
     type: ParameterType.Map,
     name: "map_type_param",
+    options: {},
   };
 
   it("valueToTupleArray", () => {
@@ -401,6 +406,7 @@ describe("EnumsParameter", () => {
       default: {},
       validValues: ["one", "two", "three", "four"],
       name: "enums_type_param",
+      options: {},
     };
 
     const tree = renderer.create(
@@ -419,9 +425,41 @@ describe("YamlParameter", () => {
       type: ParameterType.Yaml,
       default: "",
       name: "yaml_type_param",
+      options: {},
     };
 
     const tree = renderer.create(<ParameterInput definition={yamlParameter} />);
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe("EnumParameter", () => {
+  it("renders correctly", () => {
+    const enumParam: ParameterDefinition = {
+      required: true,
+      label: "Label",
+      description: "description",
+      type: ParameterType.Enum,
+      default: "",
+      name: "yaml_type_param",
+      options: {},
+    };
+
+    const tree = renderer.create(<ParameterInput definition={enumParam} />);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders creatable enum correctly", () => {
+    const creatableEnum: ParameterDefinition = {
+      required: true,
+      label: "Label",
+      description: "description",
+      type: ParameterType.Enum,
+      name: "yaml_type_param",
+      options: {},
+    };
+
+    const tree = renderer.create(<ParameterInput definition={creatableEnum} />);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/ui/src/components/ResourceTypeForm/__snapshots__/ResourceForm.test.tsx.snap
+++ b/ui/src/components/ResourceTypeForm/__snapshots__/ResourceForm.test.tsx.snap
@@ -1,5 +1,148 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EnumParameter renders correctly 1`] = `
+<div
+  className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+>
+  <label
+    className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary Mui-required css-1pysi21-MuiFormLabel-root-MuiInputLabel-root"
+    data-shrink={false}
+  >
+    Label
+    <span
+      aria-hidden={true}
+      className="MuiInputLabel-asterisk MuiFormLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+    >
+       
+      *
+    </span>
+  </label>
+  <div
+    className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-md26zr-MuiInputBase-root-MuiOutlinedInput-root"
+    onClick={[Function]}
+    variant="outlined"
+  >
+    <select
+      aria-invalid={false}
+      autoFocus={false}
+      className="MuiNativeSelect-select MuiNativeSelect-outlined MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputSizeSmall css-12ogz78-MuiNativeSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+      disabled={false}
+      multiple={false}
+      name="yaml_type_param"
+      onAnimationStart={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={true}
+    />
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiNativeSelect-icon MuiNativeSelect-iconOutlined css-1g12qau-MuiSvgIcon-root-MuiNativeSelect-icon"
+      data-testid="ArrowDropDownIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M7 10l5 5 5-5z"
+      />
+    </svg>
+    <fieldset
+      aria-hidden={true}
+      className="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+    >
+      <legend
+        className="css-1ftyaf0"
+      >
+        <span>
+          Label
+           
+          *
+        </span>
+      </legend>
+    </fieldset>
+  </div>
+  <p
+    className="MuiFormHelperText-root MuiFormHelperText-sizeSmall MuiFormHelperText-contained Mui-required css-k4qjio-MuiFormHelperText-root"
+  >
+    description
+  </p>
+</div>
+`;
+
+exports[`EnumParameter renders creatable enum correctly 1`] = `
+<div
+  className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-wb57ya-MuiFormControl-root-MuiTextField-root"
+>
+  <label
+    className="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary Mui-required css-1pysi21-MuiFormLabel-root-MuiInputLabel-root"
+    data-shrink={false}
+    htmlFor="mui-22"
+    id="mui-22-label"
+  >
+    Label
+    <span
+      aria-hidden={true}
+      className="MuiInputLabel-asterisk MuiFormLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+    >
+       
+      *
+    </span>
+  </label>
+  <div
+    className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall css-md26zr-MuiInputBase-root-MuiOutlinedInput-root"
+    onClick={[Function]}
+    variant="outlined"
+  >
+    <select
+      aria-describedby="mui-22-helper-text"
+      aria-invalid={false}
+      autoFocus={false}
+      className="MuiNativeSelect-select MuiNativeSelect-outlined MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputSizeSmall css-12ogz78-MuiNativeSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+      disabled={false}
+      id="mui-22"
+      multiple={false}
+      name="yaml_type_param"
+      onAnimationStart={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={true}
+    />
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiNativeSelect-icon MuiNativeSelect-iconOutlined css-1g12qau-MuiSvgIcon-root-MuiNativeSelect-icon"
+      data-testid="ArrowDropDownIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M7 10l5 5 5-5z"
+      />
+    </svg>
+    <fieldset
+      aria-hidden={true}
+      className="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+    >
+      <legend
+        className="css-1ftyaf0"
+      >
+        <span>
+          Label
+           
+          *
+        </span>
+      </legend>
+    </fieldset>
+  </div>
+  <p
+    className="MuiFormHelperText-root MuiFormHelperText-sizeSmall MuiFormHelperText-contained Mui-required css-k4qjio-MuiFormHelperText-root"
+    id="mui-22-helper-text"
+  >
+    description
+  </p>
+</div>
+`;
+
 exports[`EnumsParameter renders correctly 1`] = `
 Array [
   <label

--- a/ui/src/components/ResourceTypeForm/__test__/dummyResources.ts
+++ b/ui/src/components/ResourceTypeForm/__test__/dummyResources.ts
@@ -15,6 +15,7 @@ export const stringDef: ParameterDefinition = {
   label: "String Input",
   description: "Here is the description.",
   required: false,
+  options: {},
 
   type: ParameterType.String,
 
@@ -26,6 +27,7 @@ export const stringDefRequired: ParameterDefinition = {
   label: "String Input",
   description: "Here is the description.",
   required: true,
+  options: {},
 
   type: ParameterType.String,
 
@@ -37,6 +39,7 @@ export const enumDef: ParameterDefinition = {
   label: "Enum Input",
   description: "Here is the description.",
   required: false,
+  options: {},
 
   type: ParameterType.Enum,
 
@@ -49,6 +52,7 @@ export const stringsDef: ParameterDefinition = {
   label: "Multi String Input",
   description: "Here is the description.",
   required: false,
+  options: {},
 
   type: ParameterType.Strings,
 
@@ -60,6 +64,7 @@ export const boolDef: ParameterDefinition = {
   label: "Bool Input",
   description: "Here is the description.",
   required: false,
+  options: {},
 
   type: ParameterType.Bool,
 
@@ -71,6 +76,7 @@ export const boolDefaultFalseDef: ParameterDefinition = {
   label: "Bool Default False Input",
   description: "Here is the description.",
   required: false,
+  options: {},
 
   type: ParameterType.Bool,
 
@@ -82,6 +88,7 @@ export const intDef: ParameterDefinition = {
   label: "Int Input",
   description: "Here is the description.",
   required: false,
+  options: {},
 
   type: ParameterType.Int,
 
@@ -93,6 +100,7 @@ export const relevantIfDef: ParameterDefinition = {
   label: "String Input",
   description: "Here is the description.",
   required: false,
+  options: {},
 
   type: ParameterType.String,
 

--- a/ui/src/graphql/generated.ts
+++ b/ui/src/graphql/generated.ts
@@ -153,6 +153,7 @@ export type Parameter = {
 
 export type ParameterDefinition = {
   __typename?: 'ParameterDefinition';
+  creatable?: Maybe<Scalars['Boolean']>;
   default?: Maybe<Scalars['Any']>;
   description: Scalars['String'];
   label: Scalars['String'];
@@ -447,7 +448,7 @@ export type DestinationsAndTypesQuery = { __typename?: 'Query', destinationTypes
 export type SourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SourceTypesQuery = { __typename?: 'Query', sourceTypes: Array<{ __typename?: 'SourceType', apiVersion: string, kind: string, metadata: { __typename?: 'Metadata', id: string, name: string, displayName?: string | null, description?: string | null, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', supportedPlatforms: Array<string>, version: string, telemetryTypes: Array<PipelineType>, parameters: Array<{ __typename?: 'ParameterDefinition', name: string, label: string, description: string, required: boolean, type: ParameterType, validValues?: Array<string> | null, default?: any | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null }> } }> };
+export type SourceTypesQuery = { __typename?: 'Query', sourceTypes: Array<{ __typename?: 'SourceType', apiVersion: string, kind: string, metadata: { __typename?: 'Metadata', id: string, name: string, displayName?: string | null, description?: string | null, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', supportedPlatforms: Array<string>, version: string, telemetryTypes: Array<PipelineType>, parameters: Array<{ __typename?: 'ParameterDefinition', name: string, label: string, description: string, required: boolean, type: ParameterType, validValues?: Array<string> | null, creatable?: boolean | null, default?: any | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null }> } }> };
 
 export type GetConfigNamesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1228,6 +1229,7 @@ export const SourceTypesDocument = gql`
         required
         type
         validValues
+        creatable
         default
       }
       supportedPlatforms

--- a/ui/src/graphql/generated.ts
+++ b/ui/src/graphql/generated.ts
@@ -153,15 +153,20 @@ export type Parameter = {
 
 export type ParameterDefinition = {
   __typename?: 'ParameterDefinition';
-  creatable?: Maybe<Scalars['Boolean']>;
   default?: Maybe<Scalars['Any']>;
   description: Scalars['String'];
   label: Scalars['String'];
   name: Scalars['String'];
+  options: ParameterOptions;
   relevantIf?: Maybe<Array<RelevantIfCondition>>;
   required: Scalars['Boolean'];
   type: ParameterType;
   validValues?: Maybe<Array<Scalars['String']>>;
+};
+
+export type ParameterOptions = {
+  __typename?: 'ParameterOptions';
+  creatable?: Maybe<Scalars['Boolean']>;
 };
 
 export enum ParameterType {
@@ -417,14 +422,14 @@ export type DestinationTypeQueryVariables = Exact<{
 }>;
 
 
-export type DestinationTypeQuery = { __typename?: 'Query', destinationType?: { __typename?: 'DestinationType', metadata: { __typename?: 'Metadata', displayName?: string | null, name: string, icon?: string | null, description?: string | null }, spec: { __typename?: 'ResourceTypeSpec', parameters: Array<{ __typename?: 'ParameterDefinition', label: string, name: string, description: string, required: boolean, type: ParameterType, default?: any | null, validValues?: Array<string> | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null }> } } | null };
+export type DestinationTypeQuery = { __typename?: 'Query', destinationType?: { __typename?: 'DestinationType', metadata: { __typename?: 'Metadata', displayName?: string | null, name: string, icon?: string | null, description?: string | null }, spec: { __typename?: 'ResourceTypeSpec', parameters: Array<{ __typename?: 'ParameterDefinition', label: string, name: string, description: string, required: boolean, type: ParameterType, default?: any | null, validValues?: Array<string> | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null, options: { __typename?: 'ParameterOptions', creatable?: boolean | null } }> } } | null };
 
 export type GetDestinationWithTypeQueryVariables = Exact<{
   name: Scalars['String'];
 }>;
 
 
-export type GetDestinationWithTypeQuery = { __typename?: 'Query', destinationWithType: { __typename?: 'DestinationWithType', destination?: { __typename?: 'Destination', metadata: { __typename?: 'Metadata', name: string, id: string, labels?: any | null }, spec: { __typename?: 'ParameterizedSpec', type: string, parameters?: Array<{ __typename?: 'Parameter', name: string, value: any }> | null } } | null, destinationType?: { __typename?: 'DestinationType', metadata: { __typename?: 'Metadata', name: string, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', parameters: Array<{ __typename?: 'ParameterDefinition', label: string, name: string, description: string, required: boolean, type: ParameterType, default?: any | null, validValues?: Array<string> | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null }> } } | null } };
+export type GetDestinationWithTypeQuery = { __typename?: 'Query', destinationWithType: { __typename?: 'DestinationWithType', destination?: { __typename?: 'Destination', metadata: { __typename?: 'Metadata', name: string, id: string, labels?: any | null }, spec: { __typename?: 'ParameterizedSpec', type: string, parameters?: Array<{ __typename?: 'Parameter', name: string, value: any }> | null } } | null, destinationType?: { __typename?: 'DestinationType', metadata: { __typename?: 'Metadata', name: string, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', parameters: Array<{ __typename?: 'ParameterDefinition', label: string, name: string, description: string, required: boolean, type: ParameterType, default?: any | null, validValues?: Array<string> | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null, options: { __typename?: 'ParameterOptions', creatable?: boolean | null } }> } } | null } };
 
 export type SourceTypeQueryVariables = Exact<{
   name: Scalars['String'];
@@ -443,12 +448,12 @@ export type GetConfigurationQuery = { __typename?: 'Query', configuration?: { __
 export type DestinationsAndTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type DestinationsAndTypesQuery = { __typename?: 'Query', destinationTypes: Array<{ __typename?: 'DestinationType', kind: string, apiVersion: string, metadata: { __typename?: 'Metadata', id: string, name: string, displayName?: string | null, description?: string | null, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', version: string, supportedPlatforms: Array<string>, telemetryTypes: Array<PipelineType>, parameters: Array<{ __typename?: 'ParameterDefinition', label: string, type: ParameterType, name: string, description: string, default?: any | null, validValues?: Array<string> | null, required: boolean, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, value: any, operator: RelevantIfOperatorType }> | null }> } }>, destinations: Array<{ __typename?: 'Destination', metadata: { __typename?: 'Metadata', name: string }, spec: { __typename?: 'ParameterizedSpec', type: string, parameters?: Array<{ __typename?: 'Parameter', name: string, value: any }> | null } }> };
+export type DestinationsAndTypesQuery = { __typename?: 'Query', destinationTypes: Array<{ __typename?: 'DestinationType', kind: string, apiVersion: string, metadata: { __typename?: 'Metadata', id: string, name: string, displayName?: string | null, description?: string | null, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', version: string, supportedPlatforms: Array<string>, telemetryTypes: Array<PipelineType>, parameters: Array<{ __typename?: 'ParameterDefinition', label: string, type: ParameterType, name: string, description: string, default?: any | null, validValues?: Array<string> | null, required: boolean, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, value: any, operator: RelevantIfOperatorType }> | null, options: { __typename?: 'ParameterOptions', creatable?: boolean | null } }> } }>, destinations: Array<{ __typename?: 'Destination', metadata: { __typename?: 'Metadata', name: string }, spec: { __typename?: 'ParameterizedSpec', type: string, parameters?: Array<{ __typename?: 'Parameter', name: string, value: any }> | null } }> };
 
 export type SourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SourceTypesQuery = { __typename?: 'Query', sourceTypes: Array<{ __typename?: 'SourceType', apiVersion: string, kind: string, metadata: { __typename?: 'Metadata', id: string, name: string, displayName?: string | null, description?: string | null, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', supportedPlatforms: Array<string>, version: string, telemetryTypes: Array<PipelineType>, parameters: Array<{ __typename?: 'ParameterDefinition', name: string, label: string, description: string, required: boolean, type: ParameterType, validValues?: Array<string> | null, creatable?: boolean | null, default?: any | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null }> } }> };
+export type SourceTypesQuery = { __typename?: 'Query', sourceTypes: Array<{ __typename?: 'SourceType', apiVersion: string, kind: string, metadata: { __typename?: 'Metadata', id: string, name: string, displayName?: string | null, description?: string | null, icon?: string | null }, spec: { __typename?: 'ResourceTypeSpec', supportedPlatforms: Array<string>, version: string, telemetryTypes: Array<PipelineType>, parameters: Array<{ __typename?: 'ParameterDefinition', name: string, label: string, description: string, required: boolean, type: ParameterType, validValues?: Array<string> | null, default?: any | null, relevantIf?: Array<{ __typename?: 'RelevantIfCondition', name: string, operator: RelevantIfOperatorType, value: any }> | null, options: { __typename?: 'ParameterOptions', creatable?: boolean | null } }> } }> };
 
 export type GetConfigNamesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -927,6 +932,9 @@ export const DestinationTypeDocument = gql`
           value
         }
         validValues
+        options {
+          creatable
+        }
       }
     }
   }
@@ -996,6 +1004,9 @@ export const GetDestinationWithTypeDocument = gql`
             value
           }
           validValues
+          options {
+            creatable
+          }
         }
       }
     }
@@ -1158,6 +1169,9 @@ export const DestinationsAndTypesDocument = gql`
           operator
         }
         required
+        options {
+          creatable
+        }
       }
       supportedPlatforms
       telemetryTypes
@@ -1229,8 +1243,10 @@ export const SourceTypesDocument = gql`
         required
         type
         validValues
-        creatable
         default
+        options {
+          creatable
+        }
       }
       supportedPlatforms
       version

--- a/ui/src/pages/configurations/configuration/InlineDestinationCard.tsx
+++ b/ui/src/pages/configurations/configuration/InlineDestinationCard.tsx
@@ -39,6 +39,9 @@ gql`
             value
           }
           validValues
+          options {
+            creatable
+          }
         }
       }
     }

--- a/ui/src/pages/configurations/configuration/ResourceDestinationCard.tsx
+++ b/ui/src/pages/configurations/configuration/ResourceDestinationCard.tsx
@@ -50,6 +50,9 @@ gql`
               value
             }
             validValues
+            options {
+              creatable
+            }
           }
         }
       }

--- a/ui/src/pages/configurations/wizards/AssistedConfigWizard/AssistedConfigWizard.test.tsx
+++ b/ui/src/pages/configurations/wizards/AssistedConfigWizard/AssistedConfigWizard.test.tsx
@@ -43,6 +43,7 @@ const dummySourceType: SourceTypesQuery["sourceTypes"][0] = {
         required: false,
         validValues: null,
         relevantIf: null,
+        options: {},
       },
       {
         __typename: "ParameterDefinition",
@@ -54,6 +55,7 @@ const dummySourceType: SourceTypesQuery["sourceTypes"][0] = {
         required: false,
         validValues: null,
         relevantIf: null,
+        options: {},
       },
     ],
     telemetryTypes: [],
@@ -87,6 +89,7 @@ const dummyDestinationType: DestinationsAndTypesQuery["destinationTypes"][0] = {
         required: false,
         validValues: null,
         relevantIf: null,
+        options: {},
       },
       {
         __typename: "ParameterDefinition",
@@ -98,6 +101,7 @@ const dummyDestinationType: DestinationsAndTypesQuery["destinationTypes"][0] = {
         required: false,
         validValues: null,
         relevantIf: null,
+        options: {},
       },
     ],
     telemetryTypes: [],

--- a/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepThree.tsx
+++ b/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepThree.tsx
@@ -72,6 +72,9 @@ gql`
             operator
           }
           required
+          options {
+            creatable
+          }
         }
         supportedPlatforms
         telemetryTypes

--- a/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepTwo.tsx
+++ b/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepTwo.tsx
@@ -58,8 +58,10 @@ gql`
           required
           type
           validValues
-          creatable
           default
+          options {
+            creatable
+          }
         }
         supportedPlatforms
         version

--- a/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepTwo.tsx
+++ b/ui/src/pages/configurations/wizards/AssistedConfigWizard/StepTwo.tsx
@@ -58,6 +58,7 @@ gql`
           required
           type
           validValues
+          creatable
           default
         }
         supportedPlatforms


### PR DESCRIPTION
### Proposed Change
The `Parameter` model now has an `options` field which is meant to be used to customize parameters in the UI.  The first supported options is `creatable` for the `enum` type.

```go
// ParameterOptions specify further customization for inputs in the UI
type ParameterOptions struct {
	// Creatable will modify the "enum" parameter from a select to
	// a creatable select where a user can specify a custom value
	Creatable bool `json:"creatable" yaml:"creatable"`
}
```

We have an example of this in in `model/testfiles/sourcetype-experimental-parameters.yaml`

```yaml
 parameters:
    - name: creatable_enum_param
      type: enum
      label: Creatable Enum
      required: true
      description: '"BYOV" - bring your own value.'
      validValues:
        - one
        - two
        - three
        - four
      options:
        creatable: true
```

You can apply it with `go run cmd/bindplanectl/main.go apply -f model/testfiles/sourcetype-experimental-parameters.yaml`.

And in the UI we are using the `MUI Autocomplete` component to show a text input with suggested options.

![image](https://user-images.githubusercontent.com/64915094/182180666-cb4a66a5-ba94-4de3-a3b1-625e26420e99.png)

![image](https://user-images.githubusercontent.com/64915094/182180712-6e577679-d270-47c7-b68f-cb38f18c3cca.png)


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
