### PR TITLE
fix(API/UI): change config duplicate endpoint to 'copy'

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -523,7 +523,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/configurations/{name}/duplicate": {
+        "/configurations/{name}/copy": {
             "post": {
                 "produces": [
                     "application/json"
@@ -549,7 +549,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "Successful Duplication, created"
+                        "description": "Successful Copy, created"
                     },
                     "404": {
                         "description": "Not Found",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -497,7 +497,7 @@
                 }
             }
         },
-        "/configurations/{name}/duplicate": {
+        "/configurations/{name}/copy": {
             "post": {
                 "produces": [
                     "application/json"
@@ -523,7 +523,7 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "Successful Duplication, created"
+                        "description": "Successful Copy, created"
                     },
                     "404": {
                         "description": "Not Found",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -785,7 +785,7 @@ paths:
           schema:
             $ref: '#/definitions/rest.ErrorResponse'
       summary: Get configuration by name
-  /configurations/{name}/duplicate:
+  /configurations/{name}/copy:
     post:
       parameters:
       - description: the name of the configuration to duplicate
@@ -803,7 +803,7 @@ paths:
       - application/json
       responses:
         "201":
-          description: Successful Duplication, created
+          description: Successful Copy, created
         "404":
           description: Not Found
           schema:

--- a/internal/rest/api.go
+++ b/internal/rest/api.go
@@ -48,7 +48,7 @@ func AddRestRoutes(router gin.IRouter, bindplane server.BindPlane) {
 	router.GET("/configurations", func(c *gin.Context) { configurations(c, bindplane) })
 	router.GET("/configurations/:name", func(c *gin.Context) { configuration(c, bindplane) })
 	router.DELETE("/configurations/:name", func(c *gin.Context) { deleteConfiguration(c, bindplane) })
-	router.POST("/configurations/:name/duplicate", func(c *gin.Context) { duplicateConfig(c, bindplane) })
+	router.POST("/configurations/:name/copy", func(c *gin.Context) { copyConfig(c, bindplane) })
 
 	router.GET("/sources", func(c *gin.Context) { sources(c, bindplane) })
 	router.GET("/sources/:name", func(c *gin.Context) { source(c, bindplane) })
@@ -479,15 +479,15 @@ func deleteConfiguration(c *gin.Context, bindplane server.BindPlane) {
 
 // @Summary Duplicate an existing configuration
 // @Produce json
-// @Router /configurations/{name}/duplicate [post]
+// @Router /configurations/{name}/copy [post]
 // @Param 	name	path	string	true "the name of the configuration to duplicate"
 // @Param name	body	string	true "the desired name of the duplicate configuration"
-// @Success 201	"Successful Duplication, created"
+// @Success 201	"Successful Copy, created"
 // @Failure 404 {object} ErrorResponse
 // @Failure 404 {object} ErrorResponse
 // @Failure 409 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
-func duplicateConfig(c *gin.Context, bindplane server.BindPlane) {
+func copyConfig(c *gin.Context, bindplane server.BindPlane) {
 	name := c.Param("name")
 
 	// The config to make a duplicate of
@@ -502,7 +502,7 @@ func duplicateConfig(c *gin.Context, bindplane server.BindPlane) {
 		return
 	}
 
-	var req model.PostDuplicateConfigRequest
+	var req model.PostCopyConfigRequest
 	if err := c.BindJSON(&req); err != nil {
 		handleErrorResponse(c, http.StatusBadRequest, err)
 		return
@@ -528,7 +528,7 @@ func duplicateConfig(c *gin.Context, bindplane server.BindPlane) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, &model.PostDuplicateConfigResponse{
+	c.JSON(http.StatusCreated, &model.PostCopyConfigResponse{
 		Name: duplicateName,
 	})
 }

--- a/internal/rest/api_test.go
+++ b/internal/rest/api_test.go
@@ -638,7 +638,7 @@ func TestREST(t *testing.T) {
 		assert.NotContains(t, configurations, testConfiguration1)
 	})
 
-	t.Run("POST /configurations/:name/duplicate", func(t *testing.T) {
+	t.Run("POST /configurations/:name/copy", func(t *testing.T) {
 		resetStore(t, s)
 		originalName := "original"
 		newName := "newName"
@@ -650,16 +650,16 @@ func TestREST(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("404 Not Found", func(t *testing.T) {
-			endpoint := "/configurations/does-not-exist/duplicate"
+			endpoint := "/configurations/does-not-exist/copy"
 
-			resp, err := client.R().SetBody(&model.PostDuplicateConfigRequest{Name: newName}).Post(endpoint)
+			resp, err := client.R().SetBody(&model.PostCopyConfigRequest{Name: newName}).Post(endpoint)
 			require.NoError(t, err)
 
 			require.Equal(t, http.StatusNotFound, resp.StatusCode())
 		})
 
 		t.Run("400 Bad Request", func(t *testing.T) {
-			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
+			endpoint := fmt.Sprintf("/configurations/%s/copy", originalName)
 			resp, err := client.R().SetBody(`{"""`).Post(endpoint)
 			require.NoError(t, err)
 
@@ -668,18 +668,18 @@ func TestREST(t *testing.T) {
 		})
 
 		t.Run("409 Conflict", func(t *testing.T) {
-			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
-			resp, err := client.R().SetBody(&model.PostDuplicateConfigRequest{Name: thirdName}).Post(endpoint)
+			endpoint := fmt.Sprintf("/configurations/%s/copy", originalName)
+			resp, err := client.R().SetBody(&model.PostCopyConfigRequest{Name: thirdName}).Post(endpoint)
 			require.NoError(t, err)
 
 			require.Equal(t, http.StatusConflict, resp.StatusCode())
 		})
 
 		t.Run("201 Created", func(t *testing.T) {
-			endpoint := fmt.Sprintf("/configurations/%s/duplicate", originalName)
-			result := &model.PostDuplicateConfigResponse{}
+			endpoint := fmt.Sprintf("/configurations/%s/copy", originalName)
+			result := &model.PostCopyConfigResponse{}
 
-			resp, err := client.R().SetBody(&model.PostDuplicateConfigRequest{Name: newName}).SetResult(result).Post(endpoint)
+			resp, err := client.R().SetBody(&model.PostCopyConfigRequest{Name: newName}).SetResult(result).Post(endpoint)
 			require.NoError(t, err)
 
 			require.Equal(t, http.StatusCreated, resp.StatusCode())

--- a/model/rest.go
+++ b/model/rest.go
@@ -172,11 +172,11 @@ type PostAgentVersionRequest struct {
 	Version string `json:"version"`
 }
 
-// PostDuplicateConfigRequest is the REST API body for PUT /v1/configurations/{name}/duplicate
-type PostDuplicateConfigRequest struct {
+// PostCopyConfigRequest is the REST API body for PUT /v1/configurations/{name}/copy
+type PostCopyConfigRequest struct {
 	// The intended name of the duplicated config
 	Name string `json:"name"`
 }
 
-// PostDuplicateConfigResponse is the REST API response to PUT /v1/configurations/{name}/duplicate
-type PostDuplicateConfigResponse = PostDuplicateConfigRequest
+// PostCopyConfigResponse is the REST API response to PUT /v1/configurations/{name}/copy
+type PostCopyConfigResponse = PostCopyConfigRequest

--- a/ui/src/pages/configurations/configuration/DuplicateConfigDialog.tsx
+++ b/ui/src/pages/configurations/configuration/DuplicateConfigDialog.tsx
@@ -13,7 +13,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useGetConfigNamesQuery } from "../../../graphql/generated";
 import { validateNameField } from "../../../utils/forms/validate-name-field";
-import { duplicateConfig } from "../../../utils/rest/duplicate-config";
+import { copyConfig } from "../../../utils/rest/copy-config";
 
 interface Props extends DialogProps {
   currentConfigName: string;
@@ -52,7 +52,7 @@ export const DuplicateConfigDialog: React.FC<Props> = ({
   async function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
-    const status = await duplicateConfig({
+    const status = await copyConfig({
       existingName: currentConfigName,
       newName: newName,
     });

--- a/ui/src/types/rest.ts
+++ b/ui/src/types/rest.ts
@@ -44,8 +44,8 @@ export interface LabelAgentsResponse {
   errors: string[];
 }
 
-export interface DuplicateConfigPayload {
+export interface CopyConfigPayload {
   name: string;
 }
 
-export type DuplicateConfigResponse = DuplicateConfigPayload;
+export type CopyConfigResponse = CopyConfigPayload;

--- a/ui/src/utils/rest/copy-config.test.ts
+++ b/ui/src/utils/rest/copy-config.test.ts
@@ -1,10 +1,10 @@
 import nock from "nock";
-import { duplicateConfig } from "./duplicate-config";
+import { copyConfig } from "./copy-config";
 
 describe("duplicateConfig", () => {
   const existingName = "name";
   const newName = "new-name";
-  const endpoint = "/v1/configurations/name/duplicate";
+  const endpoint = "/v1/configurations/name/copy";
 
   it("correct endpoint and payload", async () => {
     let endpointCalled = false;
@@ -19,7 +19,7 @@ describe("duplicateConfig", () => {
         name: newName,
       });
 
-    await duplicateConfig({ existingName, newName });
+    await copyConfig({ existingName, newName });
 
     expect(endpointCalled).toEqual(true);
     expect(payload).toEqual({ name: newName });
@@ -27,34 +27,34 @@ describe("duplicateConfig", () => {
 
   it("created", async () => {
     nock("http://localhost:80")
-      .post("/v1/configurations/name/duplicate", (body) => {
+      .post("/v1/configurations/name/copy", (body) => {
         return true;
       })
       .reply(201, {
         name: "new-name",
       });
 
-    const status = await duplicateConfig({ existingName, newName });
+    const status = await copyConfig({ existingName, newName });
     expect(status).toEqual("created");
   });
   it("conflict", async () => {
     nock("http://localhost:80")
-      .post("/v1/configurations/name/duplicate", (body) => {
+      .post("/v1/configurations/name/copy", (body) => {
         return true;
       })
       .reply(409, {});
 
-    const status = await duplicateConfig({ existingName, newName });
+    const status = await copyConfig({ existingName, newName });
     expect(status).toEqual("conflict");
   });
   it("error", async () => {
     nock("http://localhost:80")
-      .post("/v1/configurations/name/duplicate", (body) => {
+      .post("/v1/configurations/name/copy", (body) => {
         return true;
       })
       .reply(500, {});
 
-    const status = await duplicateConfig({ existingName, newName });
+    const status = await copyConfig({ existingName, newName });
     expect(status).toEqual("error");
   });
 });

--- a/ui/src/utils/rest/copy-config.ts
+++ b/ui/src/utils/rest/copy-config.ts
@@ -1,16 +1,17 @@
-import { DuplicateConfigPayload } from "../../types/rest";
-export async function duplicateConfig({
+import { CopyConfigPayload } from "../../types/rest";
+
+export async function copyConfig({
   existingName,
   newName,
 }: {
   existingName: string;
   newName: string;
 }): Promise<"created" | "conflict" | "error"> {
-  const payload: DuplicateConfigPayload = {
+  const payload: CopyConfigPayload = {
     name: newName,
   };
   try {
-    const resp = await fetch(`/v1/configurations/${existingName}/duplicate`, {
+    const resp = await fetch(`/v1/configurations/${existingName}/copy`, {
       method: "POST",
       body: JSON.stringify(payload),
     });


### PR DESCRIPTION
### Proposed Change
- Change the configuration duplicate REST API endpoint from `/configurations/{name}/duplicate` to `/configurations/{name}/copy`

After some discussion we decided that we like `copy` for the REST API endpoint better than `duplicate`.  The upcoming CLI command will be `copy`.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
