### PR TITLE
Release v1.12.2

### DIFF
--- a/internal/otlp/record/records.go
+++ b/internal/otlp/record/records.go
@@ -178,11 +178,11 @@ func getDataPointValue(point pmetric.NumberDataPoint) interface{} {
 }
 
 // getSummaryPointValue gets the value of a summary point
-func getSummaryPointValue(point pmetric.SummaryDataPoint) map[float64]interface{} {
-	value := make(map[float64]interface{})
+func getSummaryPointValue(point pmetric.SummaryDataPoint) map[string]interface{} {
+	value := make(map[string]interface{})
 	for i := 0; i < point.QuantileValues().Len(); i++ {
 		q := point.QuantileValues().At(i)
-		value[q.Quantile()] = q.Value()
+		value[fmt.Sprintf("%v", q.Quantile())] = q.Value()
 	}
 	return value
 }

--- a/ui/src/components/SnapShotConsole/SnapShotRow/MetricsRecordRow.tsx
+++ b/ui/src/components/SnapShotConsole/SnapShotRow/MetricsRecordRow.tsx
@@ -23,6 +23,9 @@ export const MetricsRecordRow: React.FC<MetricsRecordRowProps> = ({
     [message]
   );
 
+  // value could be an object for type Summary metrics
+  const stringifiedValue = JSON.stringify(message.value);
+
   return (
     <Card classes={{ root: styles.card }}>
       <RowSummary
@@ -39,7 +42,7 @@ export const MetricsRecordRow: React.FC<MetricsRecordRowProps> = ({
             overflow={"hidden"}
             textOverflow="ellipsis"
           >
-            {message.value} {message.unit}
+            {stringifiedValue} {message.unit}
           </Typography>
         </Stack>
       </RowSummary>
@@ -57,7 +60,7 @@ export const MetricsRecordRow: React.FC<MetricsRecordRowProps> = ({
           </TableRow>
           <TableRow>
             <CellLabel>value</CellLabel>
-            <CellValue>{message.value}</CellValue>
+            <CellValue>{stringifiedValue}</CellValue>
           </TableRow>
           <TableRow>
             <CellLabel>type</CellLabel>

--- a/ui/src/components/SnapShotConsole/SnapShotRow/SnapShotRow.test.tsx
+++ b/ui/src/components/SnapShotConsole/SnapShotRow/SnapShotRow.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { Metric } from "../../../graphql/generated";
+import { MetricsRecordRow } from "./MetricsRecordRow";
+
+describe("MetricsRecordRow", () => {
+  it("renders a Summary type with Object value", () => {
+    const message: Metric = {
+      name: "go_gc_duration_seconds",
+      timestamp: "2023-04-10T18:35:21.486Z",
+      value: {
+        "0": 0.000037883,
+        "1": 0.003927915,
+        "0.25": 0.000043135,
+        "0.5": 0.000050907,
+        "0.75": 0.000065501,
+      },
+      unit: "",
+      type: "Summary",
+      attributes: {},
+      resource: {
+        cluster: "cluster-name",
+        "http.scheme": "http",
+        location: "us-east1",
+        namespace: "namespace-name",
+        "net.host.port": "9100",
+        "service.instance.id": "service-instance-id",
+        "service.name": "service-name",
+        "service.namespace": "service-namespace",
+      },
+      __typename: "Metric",
+    };
+
+    render(<MetricsRecordRow message={message} />);
+  });
+});


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This patch release resolves an issue where metric snapshots do not work with quantiles.

The following metric would cause a panic.
```
go_gc_duration_seconds{quantile="0"} 3.7883e-05
go_gc_duration_seconds{quantile="0.25"} 4.4168e-05
go_gc_duration_seconds{quantile="0.5"} 5.3092e-05
go_gc_duration_seconds{quantile="0.75"} 6.6717e-05
go_gc_duration_seconds{quantile="1"} 0.003927915
```

See https://github.com/observIQ/bindplane-op/pull/927

##### Checklist
- [x] Changes are tested
- [x] CI has passed
